### PR TITLE
feature/2: Entity 정의 및 연관관계 매핑

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,12 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
 }
 
+allOpen {
+    annotation("javax.persistence.Entity")
+    annotation("javax.persistence.MappedSuperclass")
+    annotation("javax.persistence.Embeddable")
+}
+
 noArg {
     annotation("javax.persistence.Entity")
 }

--- a/src/main/kotlin/jsonweb/exitserver/common/BaseTimeEntity.kt
+++ b/src/main/kotlin/jsonweb/exitserver/common/BaseTimeEntity.kt
@@ -1,0 +1,29 @@
+package jsonweb.exitserver.common
+
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import javax.persistence.EntityListeners
+import javax.persistence.MappedSuperclass
+import javax.persistence.PrePersist
+import javax.persistence.PreUpdate
+
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseTimeEntity {
+
+    var createdAt: String = ""
+    var modifiedAt: String = ""
+
+    @PrePersist
+    fun prePersist() {
+        this.createdAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        this.modifiedAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+    }
+
+    @PreUpdate
+    fun preUpdate() {
+        this.modifiedAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+    }
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/Cafe.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/Cafe.kt
@@ -13,7 +13,7 @@ class Cafe(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "cafe_id")
-    val id: Long = -1
+    val id: Long = 0L
 
     var name: String = name
         protected set
@@ -63,7 +63,7 @@ class OpenHour(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "open_hour_id")
-    val id: Long = -1
+    val id: Long = 0L
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "cafe_id")
@@ -91,7 +91,7 @@ class Price(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "price_id")
-    val id: Long = -1
+    val id: Long = 0L
     var target: String = target
         protected set
     var price: Int = price

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/Cafe.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/Cafe.kt
@@ -1,0 +1,108 @@
+package jsonweb.exitserver.domain.cafe.entity
+
+import jsonweb.exitserver.domain.theme.Theme
+import javax.persistence.*
+
+@Entity
+class Cafe(
+    name: String,
+    address: String,
+    tel: String,
+    homepage: String,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cafe_id")
+    val id: Long = -1
+
+    var name: String = name
+        protected set
+    var address: String = address
+        protected set
+    var themeCount: Int = 0
+        protected set
+    var themeAvgStar: Double = 0.0
+        protected set
+    var tel: String = tel
+        protected set
+    var homepage: String = homepage
+        protected set
+    var totalReviewCount: Int = 0
+        protected set
+
+    @OneToMany(mappedBy = "cafe", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var themeList: MutableList<Theme> = mutableListOf()
+        protected set
+
+    @OneToMany(mappedBy = "cafe", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var openHourList: MutableList<OpenHour> = mutableListOf()
+        protected set
+
+    @OneToMany(mappedBy = "cafe", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var priceList: MutableList<Price> = mutableListOf()
+        protected set
+
+    /**
+     * methods
+     */
+    fun addPrice(price: Price) = priceList.add(price)
+    fun addOpenHour(openHour: OpenHour) = openHourList.add(openHour)
+    fun addTheme(theme: Theme) {
+        themeList.add(theme)
+        themeCount = themeList.size
+    }
+}
+
+@Entity
+class OpenHour(
+    cafe: Cafe,
+    day: String,
+    openHour: Int,
+    closeHour: Int
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "open_hour_id")
+    val id: Long = -1
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    var cafe: Cafe = cafe
+        protected set
+
+    var day: String = day
+        protected set
+    var openHour: Int = openHour
+        protected set
+    var closeHour: Int = closeHour
+        protected set
+
+    /**
+     * methods
+     */
+}
+
+@Entity
+class Price(
+    target: String,
+    price: Int,
+    cafe: Cafe
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "price_id")
+    val id: Long = -1
+    var target: String = target
+        protected set
+    var price: Int = price
+        protected set
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    var cafe: Cafe = cafe
+        protected set
+
+    /**
+     * methods
+     */
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/entity/Cafe.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/entity/Cafe.kt
@@ -1,4 +1,0 @@
-package jsonweb.exitserver.domain.entity
-
-class Cafe {
-}

--- a/src/main/kotlin/jsonweb/exitserver/domain/entity/Review.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/entity/Review.kt
@@ -1,4 +1,0 @@
-package jsonweb.exitserver.domain.entity
-
-class Review {
-}

--- a/src/main/kotlin/jsonweb/exitserver/domain/entity/Theme.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/entity/Theme.kt
@@ -1,4 +1,0 @@
-package jsonweb.exitserver.domain.entity
-
-class Theme {
-}

--- a/src/main/kotlin/jsonweb/exitserver/domain/entity/User.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/entity/User.kt
@@ -1,4 +1,0 @@
-package jsonweb.exitserver.domain.entity
-
-class User {
-}

--- a/src/main/kotlin/jsonweb/exitserver/domain/review/Review.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/review/Review.kt
@@ -1,0 +1,47 @@
+package jsonweb.exitserver.domain.review
+
+import jsonweb.exitserver.common.BaseTimeEntity
+import jsonweb.exitserver.domain.theme.Theme
+import jsonweb.exitserver.domain.user.User
+import javax.persistence.*
+
+@Entity
+class Review(
+    content: String,
+    star: Double,
+    difficulty: Double,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "theme_id")
+    val theme: Theme
+
+): BaseTimeEntity() {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
+    val id: Long = -1
+
+    var content: String = content
+        protected set
+
+    var star: Double = star
+        protected set
+
+    var difficulty: Double = difficulty
+        protected set
+
+    var likeCount: Int = 0
+        protected set
+
+    /**
+     * methods
+     */
+    fun plusLike() {
+        likeCount++
+    }
+
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/review/Review.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/review/Review.kt
@@ -23,7 +23,7 @@ class Review(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "review_id")
-    val id: Long = -1
+    val id: Long = 0L
 
     var content: String = content
         protected set

--- a/src/main/kotlin/jsonweb/exitserver/domain/theme/Theme.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/theme/Theme.kt
@@ -1,0 +1,95 @@
+package jsonweb.exitserver.domain.theme
+
+import jsonweb.exitserver.domain.cafe.entity.Cafe
+import jsonweb.exitserver.domain.review.Review
+import javax.persistence.*
+
+@Entity
+class Theme(
+    name: String,
+    description: String,
+    imageUrl: String,
+    time: Int,
+    minPlayerCount: Int,
+    maxPlayerCount: Int,
+    difficulty: Double,
+    ageLimit: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cafe_id")
+    val cafe: Cafe,
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "theme_id")
+    val id: Long = -1
+
+    var name: String = name
+        protected set
+    var description: String = description
+        protected set
+    var imageUrl: String = imageUrl
+        protected set
+    var time: Int = time
+        protected set
+    var minPlayerCount: Int = minPlayerCount
+        protected set
+    var maxPlayerCount: Int = maxPlayerCount
+        protected set
+    var difficulty: Double = difficulty
+        protected set
+    var ageLimit: String = ageLimit
+        protected set
+    var reviewCount: Int = 0
+        protected set
+    var isReported: Boolean = false
+        protected set
+
+    @OneToMany(mappedBy = "theme", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var themeGenreList: MutableList<ThemeGenre> = mutableListOf()
+
+    @OneToMany(mappedBy = "theme", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var reviewList: MutableList<Review> = mutableListOf()
+
+    /**
+     * methods
+     */
+    fun addThemeGenre(themeGenre: ThemeGenre) = themeGenreList.add(themeGenre)
+    fun addReview(review: Review) {
+        reviewList.add(review)
+        reviewCount = reviewList.size
+    }
+
+}
+
+@Entity
+class ThemeGenre(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "theme_genre_id")
+    val id: Long = -1,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "theme_id")
+    val theme: Theme,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "genre_id")
+    val genre: Genre,
+)
+
+@Entity
+class Genre(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "genre_id")
+    val id: Long = -1,
+
+    val name: String,
+
+    // 장르에서는 테마를 참조할 경우가 없을 거 같아서 단방향으로 해도 될 듯 싶습니다
+//    @OneToMany(mappedBy = "genre", cascade = [CascadeType.ALL], orphanRemoval = true)
+//    var themeGenreList: MutableList<ThemeGenre> = mutableListOf()
+)
+
+

--- a/src/main/kotlin/jsonweb/exitserver/domain/theme/Theme.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/theme/Theme.kt
@@ -22,7 +22,7 @@ class Theme(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "theme_id")
-    val id: Long = -1
+    val id: Long = 0L
 
     var name: String = name
         protected set
@@ -67,7 +67,7 @@ class ThemeGenre(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "theme_genre_id")
-    val id: Long = -1,
+    val id: Long = 0L,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "theme_id")
@@ -83,7 +83,7 @@ class Genre(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "genre_id")
-    val id: Long = -1,
+    val id: Long = 0L,
 
     val name: String,
 

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
@@ -10,7 +10,7 @@ class User(
 ) {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
-    val id: Long = -1
+    val id: Long = 0L
 
     var nickname: String = ""
     var profileImageUrl: String = ""

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
@@ -1,0 +1,21 @@
+package jsonweb.exitserver.domain.user
+
+import jsonweb.exitserver.domain.review.Review
+import javax.persistence.*
+
+@Entity
+class User(
+    val gender: String,
+    val age: Int,
+) {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    val id: Long = -1
+
+    var nickname: String = ""
+    var profileImageUrl: String = ""
+    var exp: Int = 0
+
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var reviewList: MutableList<Review> = mutableListOf()
+}


### PR DESCRIPTION
## 관련 이슈
- #2 

## 구현한 내용 또는 수정한 내용
- Cafe, Theme, Review, User 엔티티 클래스 제작 및 연관관계 매핑

## 추가적으로 알리고 싶은 내용
- 변경 가능성이 있는 건 var, 없는건 val로 정의 하였습니다. 대부분 val 속성은 생성자에 선언했습니다.
- 사용자-리뷰 좋아요 중간다리 테이블은 나중에 리뷰 만들 때 추가하시면 될 것 같습니다.
- 프로토타입이고 해당 도메인 로직을 작성할 때 수정/보완 하면 될 것 같습니다!

## TODO / 고민하고 있는 것들  
- 중간다리 테이블 (다대다 해소용)이 개인 PK를 안 갖고 복합 PK를 구성하도록 하고 싶었는데, 이러면 PK값만 넣을 수 있는 것 같더라고요... 객체 자체를 넣어서 참조가 용이하게끔 하고 싶은데 좋은 방법이 있을까요?

