### PR TITLE
feature/3: 테스트용 계정 로직 추가

### DIFF
--- a/src/main/kotlin/jsonweb/exitserver/auth/security/SecurityConfig.kt
+++ b/src/main/kotlin/jsonweb/exitserver/auth/security/SecurityConfig.kt
@@ -38,10 +38,25 @@ class SecurityConfig(
         .apply(JwtSecurityConfig(jwtProvider))
         .and()
         .authorizeRequests()
-        .antMatchers("/oauth/kakao", "/api", ).permitAll()
+        .antMatchers("/oauth/kakao", "/api", "/test-login").permitAll()
         // Swagger 설정
-        .antMatchers("/docs/**", "/favicon.ico", "/v2/api-docs", "/v3/api-docs", "/configuration/ui","/swagger-resources/**",
-            "/configuration/security","/swagger-ui.html","/swagger-ui/#", "/webjars/**","/swagger/**", "/swagger-ui/**", "/", "/csrf", "/error").permitAll()
+        .antMatchers(
+            "/docs/**",
+            "/favicon.ico",
+            "/v2/api-docs",
+            "/v3/api-docs",
+            "/configuration/ui",
+            "/swagger-resources/**",
+            "/configuration/security",
+            "/swagger-ui.html",
+            "/swagger-ui/#",
+            "/webjars/**",
+            "/swagger/**",
+            "/swagger-ui/**",
+            "/",
+            "/csrf",
+            "/error"
+        ).permitAll()
         .antMatchers("/cafe/**").permitAll()
         .anyRequest()
         .authenticated()

--- a/src/main/kotlin/jsonweb/exitserver/common/GlobalConst.kt
+++ b/src/main/kotlin/jsonweb/exitserver/common/GlobalConst.kt
@@ -6,3 +6,5 @@ import org.slf4j.LoggerFactory
 inline fun <reified T> T.logger(): Logger {
     return LoggerFactory.getLogger(T::class.java)
 }
+
+const val TEST_KAKAO_ID = -1L

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/UserController.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/UserController.kt
@@ -10,6 +10,10 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class UserController(private val userService: UserService) {
 
+    @GetMapping("/test-login")
+    fun testLogin(): CommonResponse<JwtDto> =
+        success(userService.testLogin())
+
     @GetMapping("/oauth/kakao")
     fun kakaoLogin(code: String): CommonResponse<JwtDto> =
         success(userService.login(code))

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/UserService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/UserService.kt
@@ -3,6 +3,7 @@ package jsonweb.exitserver.domain.user
 import jsonweb.exitserver.auth.KakaoClient
 import jsonweb.exitserver.auth.jwt.JwtProvider
 import jsonweb.exitserver.auth.security.getCurrentLoginUserId
+import jsonweb.exitserver.common.TEST_KAKAO_ID
 import jsonweb.exitserver.common.USER_NOT_FOUND
 import jsonweb.exitserver.common.UserException
 import jsonweb.exitserver.util.NicknameGenerator
@@ -69,6 +70,26 @@ class UserService(
             newProfileImageUrl = form.newProfileImageUrl
         )
         return UserInfoResponse(user)
+    }
+
+    @Transactional
+    fun testLogin(): JwtDto {
+        val username = TEST_KAKAO_ID
+        val password = "1234"
+        var testUser = userRepository.findByKakaoId(TEST_KAKAO_ID)
+        if (testUser == null) {
+            val newUser = User(
+                kakaoId = TEST_KAKAO_ID,
+                nickname = nicknameGenerator.getRandomNickname(),
+                ageRange = "20~29",
+                gender = "male",
+                password = passwordEncoder.encode(password)
+            )
+            testUser = userRepository.save(newUser)
+        }
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken(username, password)
+        return JwtDto(jwtProvider.generateToken(testUser))
     }
 
 }


### PR DESCRIPTION
- JWT 인증이 필요한 로직을 수월하게 테스트하기 위해서 제작함

### 사용법
/test-login 으로 GET 요청을 보내면 테스트용 계정으로 로그인되어 JWT 토큰값이 내려갑니다.
해당값을 Authorization 헤더에 Beaer로 넣고 다른 인증이 필요한 로직 (ex. 리뷰작성)을 테스트하면 될 것 같습니다.