### PR TITLE
feature/25: 카페API 추가 기능 및 기존 기능 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.kapt3.base.Kapt.kapt
 
 plugins {
     id("org.springframework.boot") version "2.7.5"
@@ -6,6 +7,7 @@ plugins {
     kotlin("jvm") version "1.6.21"
     kotlin("plugin.spring") version "1.6.21"
     kotlin("plugin.jpa") version "1.6.21"
+    kotlin("kapt") version "1.7.10"
 }
 
 group = "jsonweb"
@@ -44,6 +46,10 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
+    //querydsl
+    implementation("com.querydsl:querydsl-jpa:5.0.0")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
+
     // test
     testImplementation("io.kotest:kotest-runner-junit5:5.4.2")
     testImplementation("io.kotest:kotest-assertions-core:5.4.2")
@@ -51,6 +57,8 @@ dependencies {
     testImplementation("io.mockk:mockk:1.12.0")
     testImplementation("org.junit.platform:junit-platform-launcher")
     testImplementation("com.h2database:h2:2.1.214")
+
+    implementation("io.github.microutils:kotlin-logging:1.12.5")
 }
 
 allOpen {

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/Cafe.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/Cafe.kt
@@ -33,9 +33,6 @@ class Cafe(
     var imageUrl: String = imageUrl
         protected set
 
-    var wrongCheck: Boolean = false
-        protected set
-
     @OneToMany(mappedBy = "cafe", cascade = [CascadeType.ALL], orphanRemoval = true)
     var themeList: MutableList<Theme> = mutableListOf()
         protected set
@@ -62,12 +59,6 @@ class Cafe(
     }
     fun decreaseReviewCount() {
         reviewCount--
-    }
-    fun markWrong() {
-        wrongCheck = true
-    }
-    fun markRight() {
-        wrongCheck = false
     }
 }
 
@@ -140,3 +131,13 @@ class CafeLike(
     @Id
     val cafeId: Long
 )
+
+@Entity
+class CafeReport(
+    private val cafeId: Long,
+    private val reportContent: String
+) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val reportId: Long = 0L
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/Cafe.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/Cafe.kt
@@ -21,7 +21,7 @@ class Cafe(
         protected set
     var themeCount: Int = 0
         protected set
-    var likeCount: Int = 0
+    var avgStar: Double = 0.0
         protected set
     var tel: String = tel
         protected set
@@ -61,12 +61,6 @@ class Cafe(
     }
     fun decreaseReviewCount() {
         reviewCount--
-    }
-    fun increaseLikeCount() {
-        likeCount++
-    }
-    fun decreaseLikeCount() {
-        likeCount--
     }
     fun markWrong() {
         wrongCheck = true

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/Cafe.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/Cafe.kt
@@ -1,6 +1,7 @@
 package jsonweb.exitserver.domain.cafe.entity
 
 import jsonweb.exitserver.domain.theme.Theme
+import java.io.Serializable
 import javax.persistence.*
 
 @Entity
@@ -124,3 +125,18 @@ class Price(
      * methods
      */
 }
+
+@Embeddable
+data class UserAndCafe(
+    private val userId: Long,
+    private val cafeId: Long
+): Serializable
+
+@Entity
+@IdClass(UserAndCafe::class)
+class CafeLike(
+    @Id
+    val userId: Long,
+    @Id
+    val cafeId: Long
+)

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeController.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeController.kt
@@ -23,25 +23,19 @@ class CafeController(private val cafeService: CafeService) {
     fun getCafeSpec(@PathVariable("cafeId") cafeId: Long): CommonResponse<CafeSpecResponse> =
         success(cafeService.getCafeSpec(cafeId))
 
-    @GetMapping("/{cafeId}/like")
+    @PutMapping("/{cafeId}/like")
     fun likeCafe(@PathVariable("cafeId") cafeId: Long): CommonResponse<Any> {
-        cafeService.likeCafe(cafeId)
+        cafeService.checkLike(cafeId)
         return success(null)
     }
 
-    @GetMapping("/{cafeId}/unlike")
-    fun unlikeCafe(@PathVariable("cafeId") cafeId: Long): CommonResponse<Any> {
-        cafeService.unlikeCafe(cafeId)
-        return success(null)
-    }
-
-    @GetMapping("/{cafeId}/wrong")
+    @PutMapping("/{cafeId}/report")
     fun reportWrongCafe(@PathVariable("cafeId") cafeId: Long): CommonResponse<Any> {
         cafeService.markCafeWrong(cafeId)
         return success(null)
     }
 
-    @GetMapping("/{cafeId}/right")
+    @PutMapping("/{cafeId}/resolve")
     fun resolveWrongCafe(@PathVariable("cafeId") cafeId: Long): CommonResponse<Any> {
         cafeService.markCafeRight(cafeId)
         return success(null)

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeController.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeController.kt
@@ -23,6 +23,18 @@ class CafeController(private val cafeService: CafeService) {
     fun getCafeSpec(@PathVariable("cafeId") cafeId: Long): CommonResponse<CafeSpecResponse> =
         success(cafeService.getCafeSpec(cafeId))
 
+    @GetMapping("/{cafeId}/like")
+    fun likeCafe(@PathVariable("cafeId") cafeId: Long): CommonResponse<Any> {
+        cafeService.likeCafe(cafeId)
+        return success(null)
+    }
+
+    @GetMapping("/{cafeId}/unlike")
+    fun unlikeCafe(@PathVariable("cafeId") cafeId: Long): CommonResponse<Any> {
+        cafeService.unlikeCafe(cafeId)
+        return success(null)
+    }
+
     @GetMapping("/{cafeId}/wrong")
     fun reportWrongCafe(@PathVariable("cafeId") cafeId: Long): CommonResponse<Any> {
         cafeService.markCafeWrong(cafeId)

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeController.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeController.kt
@@ -8,10 +8,8 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/cafe")
 class CafeController(private val cafeService: CafeService) {
     @PostMapping
-    fun registerCafe(@RequestBody form: RegisterCafeRequest): CommonResponse<Any> {
-        cafeService.registerCafe(form)
-        return success(null)
-    }
+    fun registerCafe(@RequestBody form: RegisterCafeRequest): CommonResponse<Long> =
+        success(cafeService.registerCafe(form))
 
     @DeleteMapping("/{cafeId}")
     fun deleteCafe(@PathVariable("cafeId") cafeId: Long): CommonResponse<Any> {

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeController.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeController.kt
@@ -42,7 +42,9 @@ class CafeController(private val cafeService: CafeService) {
         @RequestParam(defaultValue = "16", required = false) size: Int,
         @RequestParam(required = false) keyword: String?
     ): CommonResponse<CafeListResponse> {
-        return success(cafeService.getCafeList(page, size, sort))
+        keyword?.let {
+            return success(cafeService.getCafeListWithKeyword(keyword, page, size, sort))
+        } ?: return success(cafeService.getCafeList(page, size, sort))
     }
 
 }

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeController.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeController.kt
@@ -29,15 +29,20 @@ class CafeController(private val cafeService: CafeService) {
         return success(null)
     }
 
-    @PutMapping("/{cafeId}/report")
-    fun reportWrongCafe(@PathVariable("cafeId") cafeId: Long): CommonResponse<Any> {
-        cafeService.markCafeWrong(cafeId)
+    @PostMapping("/{cafeId}/report")
+    fun reportCafe(
+        @PathVariable("cafeId") cafeId: Long,
+        @RequestBody form: ReportCafeRequest
+    ): CommonResponse<Any> {
+        cafeService.reportCafe(cafeId, form.reportContent)
         return success(null)
     }
 
-    @PutMapping("/{cafeId}/resolve")
-    fun resolveWrongCafe(@PathVariable("cafeId") cafeId: Long): CommonResponse<Any> {
-        cafeService.markCafeRight(cafeId)
+    @DeleteMapping("{reportId}/resolve")
+    fun resolveCafe(
+        @PathVariable("reportId") reportId: Long
+    ): CommonResponse<Any> {
+        cafeService.resolveCafe(reportId)
         return success(null)
     }
 

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeDto.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeDto.kt
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Sort
 
 enum class CafeSort(private val sort: String, private val direction: Sort.Direction) {
     DEFAULT("cafeId", Sort.Direction.ASC),
-    LIKE("likeCount", Sort.Direction.DESC),
+    STAR("avgStar", Sort.Direction.DESC),
     REVIEW("reviewCount", Sort.Direction.DESC);
 
     fun getSortBy() = sort
@@ -18,6 +18,7 @@ enum class CafeSort(private val sort: String, private val direction: Sort.Direct
 
 data class CafeListResponse(
     val cafeList: List<CafeResponse>,
+    val totalNumber: Long,
     val isLast: Boolean
 )
 

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeDto.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeDto.kt
@@ -25,7 +25,7 @@ data class CafeListResponse(
 data class CafeResponse(
     val cafeId: Long,
     val name: String,
-    val isLiked: Boolean,
+    var isLiked: Boolean,
     val avgStar: Double,
     val address: String,
     val imageUrl: String,
@@ -45,7 +45,7 @@ data class CafeResponse(
 data class CafeSpecResponse(
     val cafeId: Long,
     val name: String,
-    val isLiked: Boolean,
+    var isLiked: Boolean,
     val avgStar: Double,
     val address: String,
     val tel: String,

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeDto.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeDto.kt
@@ -25,7 +25,7 @@ data class CafeResponse(
     val cafeId: Long,
     val name: String,
     val isLiked: Boolean,
-    val likeCount: Int,
+    val avgStar: Double,
     val address: String,
     val imageUrl: String,
     val reviewCount: Int
@@ -34,7 +34,7 @@ data class CafeResponse(
         cafeId = cafe.cafeId,
         name = cafe.name,
         isLiked = false, // TODO: 관련 작업 후 수정
-        likeCount = cafe.likeCount,
+        avgStar = cafe.avgStar,
         address = cafe.address,
         imageUrl = cafe.imageUrl,
         reviewCount = cafe.reviewCount
@@ -45,7 +45,7 @@ data class CafeSpecResponse(
     val cafeId: Long,
     val name: String,
     val isLiked: Boolean,
-    val likeCount: Int,
+    val avgStar: Double,
     val address: String,
     val tel: String,
     val homepage: String,
@@ -60,7 +60,7 @@ data class CafeSpecResponse(
         cafeId = cafe.cafeId,
         name = cafe.name,
         isLiked = false, // TODO: 관련 작업 후 수정
-        likeCount = cafe.likeCount,
+        avgStar = cafe.avgStar,
         address = cafe.address,
         tel = cafe.tel,
         homepage = cafe.homepage,

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeDto.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeDto.kt
@@ -34,7 +34,7 @@ data class CafeResponse(
     constructor(cafe: Cafe): this(
         cafeId = cafe.cafeId,
         name = cafe.name,
-        isLiked = false, // TODO: 관련 작업 후 수정
+        isLiked = false,
         avgStar = cafe.avgStar,
         address = cafe.address,
         imageUrl = cafe.imageUrl,
@@ -60,7 +60,7 @@ data class CafeSpecResponse(
     constructor(cafe: Cafe): this(
         cafeId = cafe.cafeId,
         name = cafe.name,
-        isLiked = false, // TODO: 관련 작업 후 수정
+        isLiked = false,
         avgStar = cafe.avgStar,
         address = cafe.address,
         tel = cafe.tel,

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeDto.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeDto.kt
@@ -117,3 +117,7 @@ data class PriceRequest(
     val headCount: String,
     val price: Int
 )
+
+data class ReportCafeRequest(
+    val reportContent: String
+)

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeKeywordRepository.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeKeywordRepository.kt
@@ -1,0 +1,4 @@
+package jsonweb.exitserver.domain.cafe
+
+interface CafeKeywordRepository {
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeLikeRepository.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeLikeRepository.kt
@@ -1,0 +1,10 @@
+package jsonweb.exitserver.domain.cafe
+
+import jsonweb.exitserver.domain.cafe.entity.Cafe
+import jsonweb.exitserver.domain.cafe.entity.CafeLike
+import jsonweb.exitserver.domain.cafe.entity.UserAndCafe
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CafeLikeRepository: JpaRepository<CafeLike, UserAndCafe> {
+    fun findAllByUserId(userId: Long): List<CafeLike>
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeReportRepository.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeReportRepository.kt
@@ -1,0 +1,7 @@
+package jsonweb.exitserver.domain.cafe
+
+import jsonweb.exitserver.domain.cafe.entity.CafeReport
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CafeReportRepository: JpaRepository<CafeReport, Long> {
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeRepository.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeRepository.kt
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 
-interface CafeRepository: JpaRepository<Cafe, Long>, JpaSpecificationExecutor<Cafe> {
+interface CafeRepository: JpaRepository<Cafe, Long> {
 }

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeRepository.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeRepository.kt
@@ -3,7 +3,9 @@ package jsonweb.exitserver.domain.cafe
 import jsonweb.exitserver.domain.cafe.entity.Cafe
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 
-interface CafeRepository: JpaRepository<Cafe, Long> {
+interface CafeRepository: JpaRepository<Cafe, Long>, JpaSpecificationExecutor<Cafe> {
 }

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeRepositoryImpl.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeRepositoryImpl.kt
@@ -2,7 +2,7 @@ package jsonweb.exitserver.domain.cafe
 
 import com.querydsl.jpa.impl.JPAQueryFactory
 import jsonweb.exitserver.domain.cafe.entity.Cafe
-import jsonweb.exitserver.domain.cafe.entity.QCafe
+import jsonweb.exitserver.domain.cafe.entity.QCafe.cafe
 import jsonweb.exitserver.domain.theme.QTheme
 import jsonweb.exitserver.domain.theme.QTheme.theme
 import mu.KotlinLogging
@@ -18,12 +18,12 @@ class CafeRepositoryImpl(
 ) : QuerydslRepositorySupport(Cafe::class.java) {
 
     fun getList(keyword: String, pageable: Pageable): Page<Cafe> {
-        val query = jpaQueryFactory.selectFrom(QCafe.cafe)
-            .leftJoin(QCafe.cafe.themeList, theme)
+        val query = jpaQueryFactory.selectFrom(cafe)
+            .leftJoin(cafe.themeList, theme)
             .fetchJoin()
             .where(
-                QCafe.cafe.name.contains(keyword)
-                    .or(QCafe.cafe.address.contains(keyword))
+                cafe.name.contains(keyword)
+                    .or(cafe.address.contains(keyword))
                     .or(theme.name.contains(keyword))
             )
             .distinct()

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeRepositoryImpl.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package jsonweb.exitserver.domain.cafe
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jsonweb.exitserver.domain.cafe.entity.Cafe
+import jsonweb.exitserver.domain.cafe.entity.QCafe
+import jsonweb.exitserver.domain.theme.QTheme
+import jsonweb.exitserver.domain.theme.QTheme.theme
+import mu.KotlinLogging
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+import org.springframework.stereotype.Repository
+
+@Repository
+class CafeRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : QuerydslRepositorySupport(Cafe::class.java) {
+
+    fun getList(keyword: String, pageable: Pageable): Page<Cafe> {
+        val query = jpaQueryFactory.selectFrom(QCafe.cafe)
+            .leftJoin(QCafe.cafe.themeList, theme)
+            .fetchJoin()
+            .where(
+                QCafe.cafe.name.contains(keyword)
+                    .or(QCafe.cafe.address.contains(keyword))
+                    .or(theme.name.contains(keyword))
+            )
+            .distinct()
+        val total = query.fetch().count()
+        val result = querydsl!!.applyPagination(pageable, query).fetch()
+        return PageImpl(result, pageable, total.toLong())
+    }
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeService.kt
@@ -14,6 +14,7 @@ class CafeService(
     private val cafeRepository: CafeRepository,
     private val cafeRepositoryImpl: CafeRepositoryImpl,
     private val cafeLikeRepository: CafeLikeRepository,
+    private val cafeReportRepository: CafeReportRepository,
     private val userService: UserService
 ) {
     @Transactional
@@ -51,15 +52,13 @@ class CafeService(
     }
 
     @Transactional
-    fun markCafeWrong(cafeId: Long) {
-        val cafe = cafeRepository.findById(cafeId).orElseThrow { throw EntityNotFoundException() }
-        cafe.markWrong()
+    fun reportCafe(cafeId: Long, reportContent: String) {
+        cafeReportRepository.save(CafeReport(cafeId, reportContent))
     }
 
     @Transactional
-    fun markCafeRight(cafeId: Long) {
-        val cafe = cafeRepository.findById(cafeId).orElseThrow { throw EntityNotFoundException() }
-        cafe.markRight()
+    fun resolveCafe(reportId: Long) {
+        cafeReportRepository.deleteById(reportId)
     }
 
     private fun makeCafe(name: String, address: String, tel: String, homepage: String): Cafe {

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeService.kt
@@ -12,7 +12,8 @@ import javax.persistence.EntityNotFoundException
 @Service
 @Transactional(readOnly = true)
 class CafeService(
-    private val cafeRepository: CafeRepository
+    private val cafeRepository: CafeRepository,
+    private val cafeRepositoryImpl: CafeRepositoryImpl
 ) {
     @Transactional
     fun registerCafe(form: RegisterCafeRequest) {
@@ -43,7 +44,17 @@ class CafeService(
             makeSort(sort)
         )
         val result = cafeRepository.findAll(pageable)
-        return CafeListResponse(result.toList().map { CafeResponse(it) }, result.isLast)
+        return CafeListResponse(result.toList().map { CafeResponse(it) }, result.totalElements, result.isLast)
+    }
+
+    fun getCafeListWithKeyword(keyword: String, page: Int, size: Int, sort: String): CafeListResponse {
+        val pageable = PageRequest.of(
+            page,
+            size,
+            makeSort(sort)
+        )
+        val result = cafeRepositoryImpl.getList(keyword, pageable)
+        return CafeListResponse(result.toList().map { CafeResponse(it) }, result.totalElements, result.isLast)
     }
 
     @Transactional

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeService.kt
@@ -18,11 +18,11 @@ class CafeService(
     private val userService: UserService
 ) {
     @Transactional
-    fun registerCafe(form: RegisterCafeRequest) {
+    fun registerCafe(form: RegisterCafeRequest): Long {
         val cafe = makeCafe(form.name, form.address, form.tel, form.homepage)
         form.openHourList.map { OpenHour(it.day, it.open, it.close, cafe) }.forEach { cafe.addOpenHour(it) }
         form.priceList.map { Price(it.headCount, it.day, it.price, cafe) }.forEach { cafe.addPrice(it) }
-        cafeRepository.save(cafe)
+        return cafeRepository.save(cafe).cafeId
     }
 
     @Transactional

--- a/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/cafe/CafeService.kt
@@ -85,11 +85,13 @@ class CafeService(
         ).and(Sort.by("cafeId"))
     }
 
+    @Transactional
     fun likeCafe(cafeId: Long) {
         val userId = userService.getCurrentLoginUser().userId
         cafeLikeRepository.save(CafeLike(userId, cafeId))
     }
 
+    @Transactional
     fun unlikeCafe(cafeId: Long) {
         val userId = userService.getCurrentLoginUser().userId
         cafeLikeRepository.deleteById(UserAndCafe(userId, cafeId))

--- a/src/main/kotlin/jsonweb/exitserver/util/QueryDslConfig.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/QueryDslConfig.kt
@@ -1,0 +1,19 @@
+package jsonweb.exitserver.util
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class QueryDslConfig {
+
+    @PersistenceContext
+    lateinit var em: EntityManager
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(em)
+    }
+}

--- a/src/main/kotlin/jsonweb/exitserver/util/QueryDslConfig.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/QueryDslConfig.kt
@@ -7,13 +7,9 @@ import javax.persistence.EntityManager
 import javax.persistence.PersistenceContext
 
 @Configuration
-class QueryDslConfig {
-
-    @PersistenceContext
-    lateinit var em: EntityManager
-
+class QueryDslConfig(
+    private val em: EntityManager
+) {
     @Bean
-    fun jpaQueryFactory(): JPAQueryFactory {
-        return JPAQueryFactory(em)
-    }
+    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(em)
 }

--- a/src/main/kotlin/jsonweb/exitserver/util/TestConfig.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/TestConfig.kt
@@ -1,0 +1,18 @@
+package jsonweb.exitserver.util
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@TestConfiguration
+class TestConfig(
+    @PersistenceContext
+    private val entityManager: EntityManager
+) {
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/src/main/kotlin/jsonweb/exitserver/util/TestConfig.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/TestConfig.kt
@@ -12,7 +12,5 @@ class TestConfig(
     private val entityManager: EntityManager
 ) {
     @Bean
-    fun jpaQueryFactory(): JPAQueryFactory {
-        return JPAQueryFactory(entityManager)
-    }
+    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(entityManager)
 }

--- a/src/test/kotlin/jsonweb/exitserver/domain/cafe/CafeLikeRepositoryTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/cafe/CafeLikeRepositoryTest.kt
@@ -1,0 +1,50 @@
+package jsonweb.exitserver.domain.cafe
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import jsonweb.exitserver.domain.cafe.entity.CafeLike
+import jsonweb.exitserver.domain.cafe.entity.UserAndCafe
+import jsonweb.exitserver.util.TestConfig
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.TestPropertySource
+
+@Import(TestConfig::class)
+@DataJpaTest
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@TestPropertySource(properties = ["spring.config.location = classpath:application-test.yml"])
+class CafeLikeRepositoryTest(
+    @Autowired
+    private val cafeLikeRepository: CafeLikeRepository
+) : AnnotationSpec() {
+    @Test
+    fun `좋아요 등록 테스트`() {
+        cafeLikeRepository.save(CafeLike(1L, 2L))
+        cafeLikeRepository.existsById(UserAndCafe(1L, 2L)) shouldBe true
+    }
+
+    @Test
+    fun `좋아요 삭제 테스트`() {
+        cafeLikeRepository.save(CafeLike(1L, 2L))
+        cafeLikeRepository.deleteById(UserAndCafe(1L, 2L))
+        cafeLikeRepository.existsById(UserAndCafe(1L, 2L)) shouldBe false
+    }
+
+    @Test
+    fun `좋아요 없는지 테스트`() {
+        cafeLikeRepository.existsById(UserAndCafe(3L, 2L)) shouldBe false
+    }
+
+    @Test
+    fun `좋아요 리스트 테스트`() {
+        cafeLikeRepository.save(CafeLike(1L, 2L))
+        cafeLikeRepository.save(CafeLike(1L, 3L))
+        val list = cafeLikeRepository.findAllByUserId(1L)
+        list.size shouldBe 2
+        list[0].cafeId shouldBe 2L
+        list[1].cafeId shouldBe 3L
+    }
+}

--- a/src/test/kotlin/jsonweb/exitserver/domain/cafe/CafeRepositoryImplTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/cafe/CafeRepositoryImplTest.kt
@@ -1,0 +1,126 @@
+package jsonweb.exitserver.domain.cafe
+
+import com.querydsl.core.util.Annotations
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.core.spec.style.Test
+import io.kotest.matchers.shouldBe
+import jsonweb.exitserver.domain.cafe.entity.Cafe
+import jsonweb.exitserver.domain.theme.Theme
+import jsonweb.exitserver.domain.theme.ThemeRepository
+import jsonweb.exitserver.util.TestConfig
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.test.context.TestPropertySource
+
+private val logger = KotlinLogging.logger {}
+
+@Import(TestConfig::class)
+@DataJpaTest
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@TestPropertySource(properties = ["spring.config.location = classpath:application-test.yml"])
+class CafeRepositoryImplTest(
+    @Autowired
+    private val cafeRepositoryImpl: CafeRepositoryImpl,
+    @Autowired
+    private val cafeRepository: CafeRepository,
+    @Autowired
+    private val themeRepository: ThemeRepository
+) : AnnotationSpec() {
+
+    @BeforeAll
+    fun `초기 설정`() {
+        for (i in 4..6) {
+            val tempCafe = Cafe("카페$i", "주소$i", "0", "asdf.net", "")
+            for (j in 1..5) {
+                tempCafe.addTheme(
+                    Theme(
+                        "테마$j",
+                        "설명",
+                        "",
+                        100,
+                        2,
+                        5,
+                        0.0,
+                        "",
+                        tempCafe
+                    )
+                )
+            }
+            cafeRepository.save(tempCafe)
+        }
+    }
+
+    @Test
+    fun `querydsl keyword 검색 잘 하는지 테스트 1`() {
+        val pageable = PageRequest.of(
+            0,
+            2,
+            Sort.by(CafeSort.valueOf("REVIEW").getDirection(), CafeSort.valueOf("REVIEW").getSortBy())
+                .and(Sort.by("cafeId"))
+        )
+        val cafeList = cafeRepositoryImpl.getList("카페", pageable)
+        cafeList.count() shouldBe 2
+        cafeList.isLast shouldBe false
+        cafeList.totalElements shouldBe 3L
+    }
+
+    @Test
+    fun `querydsl keyword 검색 잘 하는지 테스트 2`() {
+        val pageable = PageRequest.of(
+            1,
+            2,
+            Sort.by(CafeSort.valueOf("REVIEW").getDirection(), CafeSort.valueOf("REVIEW").getSortBy())
+                .and(Sort.by("cafeId"))
+        )
+        val cafeList = cafeRepositoryImpl.getList("카페", pageable)
+        cafeList.count() shouldBe 1
+        cafeList.isLast shouldBe true
+        cafeList.totalElements shouldBe 3L
+    }
+
+    @Test
+    fun `querydsl keyword 검색 잘 하는지 테스트 3`() {
+        val pageable = PageRequest.of(
+            0,
+            2,
+            Sort.by(CafeSort.valueOf("REVIEW").getDirection(), CafeSort.valueOf("REVIEW").getSortBy())
+                .and(Sort.by("cafeId"))
+        )
+        val cafeList = cafeRepositoryImpl.getList("6", pageable)
+        cafeList.count() shouldBe 1
+        cafeList.isLast shouldBe true
+    }
+
+    @Test
+    fun `querydsl keyword 검색 잘 하는지 테스트 4`() {
+        val pageable = PageRequest.of(
+            0,
+            2,
+            Sort.by(CafeSort.valueOf("REVIEW").getDirection(), CafeSort.valueOf("REVIEW").getSortBy())
+                .and(Sort.by("cafeId"))
+        )
+        val cafeList = cafeRepositoryImpl.getList("주소5", pageable)
+        cafeList.count() shouldBe 1
+        cafeList.isLast shouldBe true
+    }
+
+    @Test
+    fun `querydsl keyword 검색 잘 하는지 테스트 5`() {
+        val pageable = PageRequest.of(
+            0,
+            2,
+            Sort.by(CafeSort.valueOf("REVIEW").getDirection(), CafeSort.valueOf("REVIEW").getSortBy())
+                .and(Sort.by("cafeId"))
+        )
+        val cafeList = cafeRepositoryImpl.getList("테마3", pageable)
+        cafeList.count() shouldBe 2
+        cafeList.isLast shouldBe false
+        cafeList.totalElements shouldBe 3L
+    }
+}

--- a/src/test/kotlin/jsonweb/exitserver/domain/cafe/CafeRepositoryTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/cafe/CafeRepositoryTest.kt
@@ -8,6 +8,7 @@ import jsonweb.exitserver.domain.cafe.entity.Cafe
 import jsonweb.exitserver.domain.review.ReviewRepository
 import jsonweb.exitserver.domain.theme.GenreRepository
 import jsonweb.exitserver.domain.theme.ThemeRepository
+import jsonweb.exitserver.util.TestConfig
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -15,12 +16,14 @@ import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.context.annotation.Import
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.test.context.TestPropertySource
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.reflect.full.declaredMembers
 
+@Import(TestConfig::class)
 @DataJpaTest
 @AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
 @TestPropertySource(properties = ["spring.config.location = classpath:application-test.yml"])
@@ -44,12 +47,6 @@ class CafeRepositoryTest(
                 1, 2, 3, 4, 5
                 */
             }
-            repeat((i + 4) % 6) {
-                tempCafe.increaseLikeCount()
-                /*
-                5, 0, 1, 2, 3
-                */
-            }
             cafeRepository.save(tempCafe)
         }
     }
@@ -70,57 +67,6 @@ class CafeRepositoryTest(
     }
 
     @Test
-    fun `좋아요수로 정렬되서 리스트 나오는지 테스트`() {
-        val pageable = PageRequest.of(
-            0,
-            5,
-            Sort.by(CafeSort.valueOf("LIKE").getDirection(), CafeSort.valueOf("LIKE").getSortBy())
-                .and(Sort.by("cafeId"))
-        )
-        val result = cafeRepository.findAll(pageable).toList()
-        val answer = listOf(1L, 5L, 4L, 3L, 2L)
-        for (i in 0..4) {
-            result[i].cafeId shouldBe answer[i]
-        }
-    }
-
-    @Test
-    fun `좋아요수로 페이징 처리도 잘 되는지 테스트 1`() {
-        val pageable = PageRequest.of(
-            0,
-            3,
-            Sort.by(CafeSort.valueOf("LIKE").getDirection(), CafeSort.valueOf("LIKE").getSortBy())
-                .and(Sort.by("cafeId"))
-        )
-        val result = cafeRepository.findAll(pageable)
-
-        result.isLast shouldBe false // check isLast
-
-        val answer = listOf(1L, 5L, 4L)
-        for (i in 0..2) {
-            result.toList()[i].cafeId shouldBe answer[i]
-        }
-    }
-
-    @Test
-    fun `좋아요수로 페이징 처리도 잘 되는지 테스트 2`() {
-        val pageable = PageRequest.of(
-            1,
-            3,
-            Sort.by(CafeSort.valueOf("LIKE").getDirection(), CafeSort.valueOf("LIKE").getSortBy())
-                .and(Sort.by("cafeId"))
-        )
-        val result = cafeRepository.findAll(pageable)
-
-        result.isLast shouldBe true // check isLast
-
-        val answer = listOf(3L, 2L)
-        for (i in 0..1) {
-            result.toList()[i].cafeId shouldBe answer[i]
-        }
-    }
-
-    @Test
     fun `리뷰수로 페이징 처리도 잘 되는지 테스트 1`() {
         val pageable = PageRequest.of(
             0,
@@ -131,6 +77,7 @@ class CafeRepositoryTest(
         val result = cafeRepository.findAll(pageable)
 
         result.isLast shouldBe false // check isLast
+        result.totalElements shouldBe 5
 
         val answer = listOf(5L, 4L, 3L)
         for (i in 0..2) {
@@ -149,6 +96,7 @@ class CafeRepositoryTest(
         val result = cafeRepository.findAll(pageable)
 
         result.isLast shouldBe true // check isLast
+        result.totalElements shouldBe 5
 
         val answer = listOf(2L, 1L)
         for (i in 0..1) {

--- a/src/test/kotlin/jsonweb/exitserver/domain/cafe/CafeServiceTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/cafe/CafeServiceTest.kt
@@ -4,12 +4,21 @@ import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import jsonweb.exitserver.auth.KakaoClient
 import jsonweb.exitserver.domain.cafe.entity.Cafe
+import jsonweb.exitserver.domain.user.User
+import jsonweb.exitserver.domain.user.UserRepository
+import jsonweb.exitserver.domain.user.UserService
 import java.util.*
 
 class CafeServiceTest : AnnotationSpec() {
     private val cafeRepository = mockk<CafeRepository>()
-    private val cafeService = CafeService(cafeRepository)
+    private val cafeRepositoryImpl = mockk<CafeRepositoryImpl>()
+    private val userRepository = mockk<UserRepository>()
+    private val cafeLikeRepository = mockk<CafeLikeRepository>()
+    private val userService = mockk<UserService>()
+    private val cafeService = CafeService(cafeRepository, cafeRepositoryImpl, cafeLikeRepository, userService)
+
 
     @BeforeAll
     fun `초기 설정`() {

--- a/src/test/kotlin/jsonweb/exitserver/domain/cafe/CafeServiceTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/cafe/CafeServiceTest.kt
@@ -39,4 +39,14 @@ class CafeServiceTest : AnnotationSpec() {
         val testCafe = cafeRepository.findById(1L)
         testCafe.get().wrongCheck shouldBe false
     }
+
+    @Test
+    fun `좋아요 마킹 테스트 (CafeSpecResponse)`() {
+
+    }
+
+    @Test
+    fun `좋아요 마킹 테스트 (CafeListResponse)`() {
+
+    }
 }


### PR DESCRIPTION
### 작업 내용
- 카페 리스트 조회에 쿼리 결과 숫자 추가, Response 에 반영
&rarr; DataJpaTest 로 테스트 완료
- 카페 조회에 키워드 검색 반영 (queryDSL 적용, 사용)
&rarr; DataJpaTest 로 테스트 완료
- 카페 좋아요 수 제거, 평균 만족도로 변경
&rarr; 테스트 불필요
- User 카페 좋아요, 좋아요 취소, 리스트에 좋아요 마킹 기능 추가
&raar; 좋아요, 좋아요 취소는 복합키 테이블 관련이므로 DataJpaTest 로 테스트 완료

### 고민 사항
- 카페 리스트 조회에 유저에 따른 마킹 기능 어떻게 테스트 해야할지 모르겠음
(카카오 유저 로그인이 되어있어야 하는데 의존성이 너무 많음)
