### PR TITLE
feature/46: 뱃지, 칭호 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
     implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
-    //querydsl
+    // querydsl
     implementation("com.querydsl:querydsl-jpa:5.0.0")
     kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
 
@@ -60,6 +60,9 @@ dependencies {
     testImplementation("com.h2database:h2:2.1.214")
 
     implementation("io.github.microutils:kotlin-logging:1.12.5")
+
+    // aop
+    implementation("org.springframework.boot:spring-boot-starter-aop")
 }
 
 allOpen {

--- a/src/main/kotlin/jsonweb/exitserver/JsonWebServerApplication.kt
+++ b/src/main/kotlin/jsonweb/exitserver/JsonWebServerApplication.kt
@@ -2,12 +2,12 @@ package jsonweb.exitserver
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.EnableAspectJAutoProxy
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 import springfox.documentation.annotations.ApiIgnore
 
-@SpringBootApplication
-class JsonWebServerApplication
+
 
 @ApiIgnore
 @RestController
@@ -15,6 +15,10 @@ class HelloController {
     @GetMapping
     fun hello() = "hello!"
 }
+
+@SpringBootApplication
+@EnableAspectJAutoProxy
+class JsonWebServerApplication
 
 fun main(args: Array<String>) {
     runApplication<JsonWebServerApplication>(*args)

--- a/src/main/kotlin/jsonweb/exitserver/JsonWebServerApplication.kt
+++ b/src/main/kotlin/jsonweb/exitserver/JsonWebServerApplication.kt
@@ -8,14 +8,6 @@ import org.springframework.web.bind.annotation.RestController
 import springfox.documentation.annotations.ApiIgnore
 
 
-
-@ApiIgnore
-@RestController
-class HelloController {
-    @GetMapping
-    fun hello() = "hello!"
-}
-
 @SpringBootApplication
 @EnableAspectJAutoProxy
 class JsonWebServerApplication

--- a/src/main/kotlin/jsonweb/exitserver/auth/security/PrincipalDetails.kt
+++ b/src/main/kotlin/jsonweb/exitserver/auth/security/PrincipalDetails.kt
@@ -1,13 +1,11 @@
 package jsonweb.exitserver.auth.security
 
-import jsonweb.exitserver.common.USER_NOT_FOUND
 import jsonweb.exitserver.domain.user.User
 import jsonweb.exitserver.domain.user.UserRepository
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsService
-import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.stereotype.Service
 
 class PrincipalDetails(private val user: User) : UserDetails {
@@ -16,7 +14,9 @@ class PrincipalDetails(private val user: User) : UserDetails {
         authorities.add { user.role.toString() }
         return authorities
     }
+
     override fun getPassword(): String = user.password
+
     // 유저를 식별할 수 있는 고유값을 넘겨줘야 함 (DB PK)
     override fun getUsername(): String = user.userId.toString()
     override fun isAccountNonExpired(): Boolean = true
@@ -31,13 +31,13 @@ class PrincipalDetailsService(
 ) : UserDetailsService {
     override fun loadUserByUsername(userId: String) = PrincipalDetails(
         userRepository.findById(userId.toLong())
-            .orElseThrow { UsernameNotFoundException(USER_NOT_FOUND) }
+            .orElseThrow()
     )
 }
 
 // principal 에는 username (User PK 값) 이 문자열로 들어있다
 fun getCurrentLoginUserId() = (SecurityContextHolder
-        .getContext()
-        .authentication
-        .principal as String)
-        .toLong()
+    .getContext()
+    .authentication
+    .principal as String)
+    .toLong()

--- a/src/main/kotlin/jsonweb/exitserver/common/BaseTimeEntity.kt
+++ b/src/main/kotlin/jsonweb/exitserver/common/BaseTimeEntity.kt
@@ -16,14 +16,17 @@ abstract class BaseTimeEntity {
     var createdAt: String = ""
     var modifiedAt: String = ""
 
+    private fun dateFormat(): String = LocalDateTime.now()
+        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+
     @PrePersist
     fun prePersist() {
-        this.createdAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-        this.modifiedAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        createdAt = dateFormat()
+        modifiedAt = dateFormat()
     }
 
     @PreUpdate
     fun preUpdate() {
-        this.modifiedAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+        modifiedAt = dateFormat()
     }
 }

--- a/src/main/kotlin/jsonweb/exitserver/common/CommonController.kt
+++ b/src/main/kotlin/jsonweb/exitserver/common/CommonController.kt
@@ -1,0 +1,21 @@
+package jsonweb.exitserver.common
+
+import jsonweb.exitserver.domain.user.UserService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import springfox.documentation.annotations.ApiIgnore
+
+@ApiIgnore
+@RestController
+class HelloController {
+    @GetMapping
+    fun hello() = "hello!"
+}
+
+@RestController
+class BadgeController(private val userService: UserService) {
+//    @PostMapping("/badges/{badgeId}")
+//    fun addBadge(@PathVariable badgeId: Long) {
+//        userService.getCurrentLoginUser().addBadge(Badge.EIXTER)
+//    }
+}

--- a/src/main/kotlin/jsonweb/exitserver/common/CustomExceptions.kt
+++ b/src/main/kotlin/jsonweb/exitserver/common/CustomExceptions.kt
@@ -1,7 +1,4 @@
 package jsonweb.exitserver.common
 
-const val USER_NOT_FOUND = "user not found."
-class UserException(message: String) : RuntimeException(message)
-
 const val INQUIRY_CANCEL_ERROR = "only could cancel during wait status."
 class InquiryException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/jsonweb/exitserver/domain/boast/Boast.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/boast/Boast.kt
@@ -102,16 +102,3 @@ class BoastLike(
     val boastId: Long,
 )
 
-@Entity
-class BoastReport(
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "boast_report_id")
-    val id: Long = 0L,
-
-    val reportContent: String,
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "boast_id")
-    val boast: Boast
-)
-

--- a/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastController.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastController.kt
@@ -6,7 +6,9 @@ import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
 
 @RestController
-class BoastController(private val boastService: BoastService) {
+class BoastController(
+    private val boastService: BoastService
+) {
     @GetMapping("/boasts")
     fun getAllBoasts(
         @RequestParam(defaultValue = "DATE", required = false) sort: String,
@@ -53,15 +55,6 @@ class BoastController(private val boastService: BoastService) {
     @PutMapping("/boasts/{boastId}/likes")
     fun likeBoast(@PathVariable("boastId") id: Long): CommonResponse<Any> {
         boastService.checkLike(id)
-        return success()
-    }
-
-    @PostMapping("/boasts/{boastId}/reports")
-    fun reportBoast(
-        @PathVariable("boastId") id: Long,
-        @RequestBody form: ReportBoastRequest
-    ): CommonResponse<Any> {
-        boastService.reportBoast(id, form)
         return success()
     }
 }

--- a/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastRepository.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastRepository.kt
@@ -19,9 +19,6 @@ interface BoastRepository : JpaRepository<Boast, Long>, BoastRepositoryCustom {
 interface BoastLikeRepository : JpaRepository<BoastLike, BoastLikeId> {
 }
 
-interface BoastReportRepository : JpaRepository<BoastReport, Long> {
-}
-
 interface BoastRepositoryCustom {
     fun findAllBoasts(pageable: Pageable): Page<Boast>
     fun findAllByUser(user: User, pageable: Pageable): Page<Boast>

--- a/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastService.kt
@@ -4,7 +4,7 @@ import jsonweb.exitserver.common.logger
 import jsonweb.exitserver.domain.theme.ThemeRepository
 import jsonweb.exitserver.domain.user.UserService
 import jsonweb.exitserver.util.Exp
-import jsonweb.exitserver.util.badge.BadgeType
+import jsonweb.exitserver.util.badge.BadgeDomain
 import jsonweb.exitserver.util.badge.CheckBadge
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -72,7 +72,7 @@ class BoastService(
     }
 
     @Exp(20)
-    @CheckBadge(BadgeType.BOAST)
+    @CheckBadge(BadgeDomain.BOAST)
     @Transactional
     fun createBoast(form: BoastRequest) {
         val user = userService.getCurrentLoginUser()
@@ -86,12 +86,6 @@ class BoastService(
             boast.addHashtag(BoastHashtag(hashtag = "#$it", boast = boast))
         }
         user.addMyBoast(boast)
-
-//        // 인증 글 10개 작성 시 탈출중독 뱃지 획득
-//        if (user.myBoastList.size == 10) {
-//            log.info("${user.nickname}님이 탈출중독 뱃지 획득.")
-//            user.addBadge(BadgeEnum.ADDICTED_ESCAPE)
-//        }
     }
 
     @Transactional

--- a/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastService.kt
@@ -2,6 +2,7 @@ package jsonweb.exitserver.domain.boast
 
 import jsonweb.exitserver.domain.theme.ThemeRepository
 import jsonweb.exitserver.domain.user.UserService
+import jsonweb.exitserver.util.Exp
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -64,6 +65,7 @@ class BoastService(
         return boasts.toBoastListResponse()
     }
 
+    @Exp(20)
     @Transactional
     fun createBoast(form: BoastRequest) {
         val user = userService.getCurrentLoginUser()
@@ -114,6 +116,7 @@ class BoastService(
     /**
      * 테스트용
      */
+    @Exp(20)
     @Transactional
     fun createDummyBoast(form: BoastRequest, dummyKakaoId: Long) {
         val user = userService.getTestUser(dummyKakaoId)

--- a/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastService.kt
@@ -1,8 +1,11 @@
 package jsonweb.exitserver.domain.boast
 
+import jsonweb.exitserver.common.logger
 import jsonweb.exitserver.domain.theme.ThemeRepository
 import jsonweb.exitserver.domain.user.UserService
 import jsonweb.exitserver.util.Exp
+import jsonweb.exitserver.util.badge.BadgeType
+import jsonweb.exitserver.util.badge.CheckBadge
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -18,6 +21,9 @@ class BoastService(
     private val boastLikeRepository: BoastLikeRepository,
     private val boastReportRepository: BoastReportRepository
 ) {
+
+    val log = logger()
+
     private fun String.toSort(): Sort {
         return if (this == "DATE") {
             Sort.by(Sort.Direction.DESC, "modifiedAt")
@@ -66,6 +72,7 @@ class BoastService(
     }
 
     @Exp(20)
+    @CheckBadge(BadgeType.BOAST)
     @Transactional
     fun createBoast(form: BoastRequest) {
         val user = userService.getCurrentLoginUser()
@@ -79,6 +86,12 @@ class BoastService(
             boast.addHashtag(BoastHashtag(hashtag = "#$it", boast = boast))
         }
         user.addMyBoast(boast)
+
+//        // 인증 글 10개 작성 시 탈출중독 뱃지 획득
+//        if (user.myBoastList.size == 10) {
+//            log.info("${user.nickname}님이 탈출중독 뱃지 획득.")
+//            user.addBadge(BadgeEnum.ADDICTED_ESCAPE)
+//        }
     }
 
     @Transactional
@@ -106,6 +119,7 @@ class BoastService(
         }
     }
 
+    @Exp(20)
     @Transactional
     fun reportBoast(boastId: Long, form: ReportBoastRequest) {
         val boast = boastRepository.findById(boastId).orElseThrow()

--- a/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/boast/BoastService.kt
@@ -1,6 +1,5 @@
 package jsonweb.exitserver.domain.boast
 
-import jsonweb.exitserver.common.logger
 import jsonweb.exitserver.domain.theme.ThemeRepository
 import jsonweb.exitserver.domain.user.UserService
 import jsonweb.exitserver.util.Exp
@@ -18,12 +17,8 @@ class BoastService(
     private val userService: UserService,
     private val themeRepository: ThemeRepository,
     private val boastRepository: BoastRepository,
-    private val boastLikeRepository: BoastLikeRepository,
-    private val boastReportRepository: BoastReportRepository
+    private val boastLikeRepository: BoastLikeRepository
 ) {
-
-    val log = logger()
-
     private fun String.toSort(): Sort {
         return if (this == "DATE") {
             Sort.by(Sort.Direction.DESC, "modifiedAt")
@@ -77,11 +72,13 @@ class BoastService(
     fun createBoast(form: BoastRequest) {
         val user = userService.getCurrentLoginUser()
         val theme = themeRepository.findById(form.themeId).orElseThrow()
-        val boast = boastRepository.save(Boast(
-            user = user,
-            theme = theme,
-            imageUrl = form.imageUrl
-        ))
+        val boast = boastRepository.save(
+            Boast(
+                user = user,
+                theme = theme,
+                imageUrl = form.imageUrl
+            )
+        )
         form.hashtags.forEach {
             boast.addHashtag(BoastHashtag(hashtag = "#$it", boast = boast))
         }
@@ -113,14 +110,6 @@ class BoastService(
         }
     }
 
-    @Exp(20)
-    @Transactional
-    fun reportBoast(boastId: Long, form: ReportBoastRequest) {
-        val boast = boastRepository.findById(boastId).orElseThrow()
-        boastReportRepository.save(BoastReport(boast = boast, reportContent = form.reportContent))
-        boast.setInvisible()
-    }
-
     /**
      * 테스트용
      */
@@ -129,10 +118,13 @@ class BoastService(
     fun createDummyBoast(form: BoastRequest, dummyKakaoId: Long) {
         val user = userService.getTestUser(dummyKakaoId)
         val theme = themeRepository.findById(form.themeId).orElseThrow()
-        val boast = boastRepository.save(Boast(
-            user = user,
-            theme = theme,
-            imageUrl = form.imageUrl))
+        val boast = boastRepository.save(
+            Boast(
+                user = user,
+                theme = theme,
+                imageUrl = form.imageUrl
+            )
+        )
         form.hashtags.forEach {
             boast.addHashtag(BoastHashtag(hashtag = "#$it", boast = boast))
         }

--- a/src/main/kotlin/jsonweb/exitserver/domain/inquiry/InquiryCategoryEnum.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/inquiry/InquiryCategoryEnum.kt
@@ -1,0 +1,9 @@
+package jsonweb.exitserver.domain.inquiry
+
+enum class InquiryCategoryEnum(private val kor: String) {
+    CAFE("카페 등록 요청"),
+    EDIT("정보 수정 요청"),
+    SERVICE("서비스 관련"),
+    ETC("기타 문의 사항");
+    fun kor() = kor
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/inquiry/InquiryService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/inquiry/InquiryService.kt
@@ -4,6 +4,8 @@ import jsonweb.exitserver.common.INQUIRY_CANCEL_ERROR
 import jsonweb.exitserver.common.InquiryException
 import jsonweb.exitserver.domain.user.UserService
 import jsonweb.exitserver.util.Exp
+import jsonweb.exitserver.util.badge.BadgeDomain
+import jsonweb.exitserver.util.badge.CheckBadge
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import javax.persistence.EntityNotFoundException
@@ -28,6 +30,7 @@ class InquiryService(
     fun getInquiryToDto(id: Long) = InquiryResponse(getInquiry(id))
 
     @Exp(30)
+    @CheckBadge(BadgeDomain.INQUIRY)
     @Transactional
     fun createInquiry(form: InquiryRequest): List<InquiryResponse> {
         val user = userService.getCurrentLoginUser()

--- a/src/main/kotlin/jsonweb/exitserver/domain/inquiry/InquiryService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/inquiry/InquiryService.kt
@@ -3,6 +3,7 @@ package jsonweb.exitserver.domain.inquiry
 import jsonweb.exitserver.common.INQUIRY_CANCEL_ERROR
 import jsonweb.exitserver.common.InquiryException
 import jsonweb.exitserver.domain.user.UserService
+import jsonweb.exitserver.util.Exp
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import javax.persistence.EntityNotFoundException
@@ -26,6 +27,7 @@ class InquiryService(
 
     fun getInquiryToDto(id: Long) = InquiryResponse(getInquiry(id))
 
+    @Exp(30)
     @Transactional
     fun createInquiry(form: InquiryRequest): List<InquiryResponse> {
         val user = userService.getCurrentLoginUser()

--- a/src/main/kotlin/jsonweb/exitserver/domain/report/Report.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/report/Report.kt
@@ -1,0 +1,45 @@
+package jsonweb.exitserver.domain.report
+
+import jsonweb.exitserver.common.BaseTimeEntity
+import jsonweb.exitserver.domain.boast.Boast
+import jsonweb.exitserver.domain.review.Review
+import jsonweb.exitserver.domain.user.User
+import javax.persistence.*
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+class Report(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val reportId: Long = 0L,
+    val content: String,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User,
+) : BaseTimeEntity() {
+
+    var status: ReportStatus = ReportStatus.WAITING
+        protected set
+
+    fun resolve() {
+        status = ReportStatus.RESOLVED
+    }
+}
+
+@Entity
+class BoastReport(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "boast_id")
+    val boast: Boast,
+    content: String,
+    user: User,
+) : Report(user = user, content = content)
+
+@Entity
+class ReviewReport(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    val review: Review,
+    content: String,
+    user: User
+) : Report(user = user, content = content)

--- a/src/main/kotlin/jsonweb/exitserver/domain/report/ReportDto.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/report/ReportDto.kt
@@ -1,0 +1,11 @@
+package jsonweb.exitserver.domain.report
+
+data class BoastReportRequest(
+    val boastId: Long,
+    val content: String
+)
+
+data class ReviewReportRequest(
+    val reviewId: Long,
+    val content: String
+)

--- a/src/main/kotlin/jsonweb/exitserver/domain/report/ReportEnum.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/report/ReportEnum.kt
@@ -1,0 +1,15 @@
+package jsonweb.exitserver.domain.report
+
+enum class ReportEnum(private val kor: String) {
+    IRRELEVANT("관련 없는 내용이에요"),
+    AD_PROMO("광고 / 홍보성 게시글이에요"),
+    SEXUAL_VIOLENCE_AVERSION("선정적이거나 폭력, 혐오적인 내용이에요"),
+    COPYRIGHT_INFRINGEMENT("무단 도용, 저작권 침해가 의심되어요"),
+    PERSONAL_INFORMATION("개인정보 노출이 우려되어요");
+
+    fun kor() = kor
+}
+
+enum class ReportStatus {
+    WAITING, RESOLVED
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/report/ReportRepository.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/report/ReportRepository.kt
@@ -1,0 +1,6 @@
+package jsonweb.exitserver.domain.report
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReportRepository : JpaRepository<Report, Long> {
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/report/ReportService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/report/ReportService.kt
@@ -1,0 +1,48 @@
+package jsonweb.exitserver.domain.report
+
+import jsonweb.exitserver.domain.boast.BoastRepository
+import jsonweb.exitserver.domain.review.ReviewRepository
+import jsonweb.exitserver.domain.user.UserService
+import jsonweb.exitserver.util.badge.BadgeDomain
+import jsonweb.exitserver.util.badge.CheckBadge
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class ReportService(
+    private val userService: UserService,
+    private val reviewRepository: ReviewRepository,
+    private val boastRepository: BoastRepository,
+    private val reportRepository: ReportRepository
+) {
+    // 리뷰 신고
+    @CheckBadge(BadgeDomain.REVIEW)
+    @Transactional
+    fun createReviewReport(form: ReviewReportRequest) {
+        val user = userService.getCurrentLoginUser()
+        val review = reviewRepository.findById(form.reviewId).orElseThrow()
+        user.addReport(ReviewReport(review = review, content = form.content, user = user))
+    }
+
+    // 인증 신고
+    @Transactional
+    fun createBoastReport(form: BoastReportRequest) {
+        val user = userService.getCurrentLoginUser()
+        val boast = boastRepository.findById(form.boastId).orElseThrow()
+        user.addReport(BoastReport(boast = boast, content = form.content, user = user))
+    }
+
+    // TODO : 신고 전체 조회
+
+    // TODO : 리뷰 신고 전체 조회
+
+    // TODO : 인증 신고 전체 조회
+
+    // 신고 해결
+    @Transactional
+    fun resolveReport(reportId: Long) {
+        val report = reportRepository.findById(reportId).orElseThrow()
+        report.resolve()
+    }
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/review/EmotionEnum.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/review/EmotionEnum.kt
@@ -1,20 +1,23 @@
 package jsonweb.exitserver.domain.review
 
-import java.util.*
-
-enum class Emotions(private val emotion: String, private val emoji: String, private val pastTense: String) {
+enum class EmotionEnum(
+    private val kor: String,
+    private val emoji: String,
+    private val pastTense: String
+) {
     FUN("재미있어요", "\uD83D\uDE09", "재미있어했어요"),
     SCARY("무서워요", "\uD83D\uDE28", "무서워했어요"),
     FRESH("신선해요", "\uD83E\uDD29", "신선했어요"),
     SAD("슬퍼요", "\uD83E\uDD72", "슬퍼했어요"),
     TOUCH("여운이남아요", "\uD83D\uDE27", "여운이남았어요"),
     BLANK("", "", "");
+
     companion object {
-        private val emotionsMap: Map<String, Emotions> = values().associateBy { it.emotion }
-        fun findByEmotion(emotion: String) = emotionsMap[emotion]
+        private val emotionEnumMap: Map<String, EmotionEnum> = values().associateBy { it.kor }
+        fun findByEmotion(emotion: String) = emotionEnumMap[emotion]
     }
 
-    fun getEmotion() = emotion
-    fun getEmoji() = emoji
-    fun getPastTense() = pastTense
+    fun kor() = kor
+    fun emoji() = emoji
+    fun pastTense() = pastTense
 }

--- a/src/main/kotlin/jsonweb/exitserver/domain/review/ReviewDto.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/review/ReviewDto.kt
@@ -76,8 +76,8 @@ data class ReviewResponse(
         modifiedAt = review.modifiedAt.toDotFormat(),
         star = review.star,
         difficulty = review.difficulty,
-        emotionFirst = review.emotionFirst + Emotions.findByEmotion(review.emotionFirst)!!.getEmoji(),
-        emotionSecond = review.emotionSecond + Emotions.findByEmotion(review.emotionSecond)!!.getEmoji(),
+        emotionFirst = review.emotionFirst + EmotionEnum.findByEmotion(review.emotionFirst)!!.emoji(),
+        emotionSecond = review.emotionSecond + EmotionEnum.findByEmotion(review.emotionSecond)!!.emoji(),
         content = review.content,
         themeName = review.theme.name,
         themeGenre = review.theme.themeGenreList.map { it.genre.genreName }

--- a/src/main/kotlin/jsonweb/exitserver/domain/review/ReviewService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/review/ReviewService.kt
@@ -1,7 +1,9 @@
 package jsonweb.exitserver.domain.review
 
+import jsonweb.exitserver.common.logger
 import jsonweb.exitserver.domain.theme.ThemeRepository
 import jsonweb.exitserver.domain.user.UserService
+import jsonweb.exitserver.util.badge.BadgeEnum
 import jsonweb.exitserver.util.Exp
 import org.modelmapper.ModelMapper
 import org.springframework.data.domain.PageRequest
@@ -20,6 +22,8 @@ class ReviewService(
     private val modelMapper: ModelMapper
 ) {
 
+    val log = logger()
+
     @Exp(20)
     @Transactional
     fun createReview(themeId: Long, form: CreateReviewRequest) {
@@ -29,6 +33,12 @@ class ReviewService(
         reviewRepository.save(review)
         theme.addReview(review)
         theme.cafe.addReview(form.star)
+        
+        // 첫 리뷰이면 엑시터 뱃지 획득
+        if (user.reviewList.size == 1) {
+            log.info("${user.nickname}님이 '엑시터' 뱃지를 획득.")
+            user.addBadge(BadgeEnum.EIXTER)
+        }
     }
 
     @Transactional

--- a/src/main/kotlin/jsonweb/exitserver/domain/review/ReviewService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/review/ReviewService.kt
@@ -1,14 +1,13 @@
 package jsonweb.exitserver.domain.review
 
-import jsonweb.exitserver.domain.cafe.CafeRepository
 import jsonweb.exitserver.domain.theme.ThemeRepository
 import jsonweb.exitserver.domain.user.UserService
+import jsonweb.exitserver.util.Exp
 import org.modelmapper.ModelMapper
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.EnumMap
 import javax.persistence.EntityNotFoundException
 
 @Service
@@ -17,11 +16,11 @@ class ReviewService(
     private val reviewRepository: ReviewRepository,
     private val reviewLikeRepository: ReviewLikeRepository,
     private val themeRepository: ThemeRepository,
-    private val cafeRepository: CafeRepository,
     private val userService: UserService,
     private val modelMapper: ModelMapper
 ) {
 
+    @Exp(20)
     @Transactional
     fun createReview(themeId: Long, form: CreateReviewRequest) {
         val user = userService.getCurrentLoginUser()
@@ -149,7 +148,7 @@ class ReviewService(
     }
 
     private fun incrementCount(emotion: String, emotionCount: MutableMap<String, Int>) {
-        if (!emotion.isNullOrEmpty()) {
+        if (emotion.isNotEmpty()) {
             val curCount = emotionCount[emotion]
             emotionCount[emotion] = curCount!! + 1
         }

--- a/src/main/kotlin/jsonweb/exitserver/domain/review/ReviewService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/review/ReviewService.kt
@@ -30,7 +30,7 @@ class ReviewService(
         val user = userService.getCurrentLoginUser()
         val theme = themeRepository.findById(themeId).orElseThrow()
         val review = modelMapper.map(ReviewWithTheme(form, theme, user), Review::class.java)
-        reviewRepository.save(review)
+        user.addReview(review)
         theme.addReview(review)
         theme.cafe.addReview(form.star)
     }

--- a/src/main/kotlin/jsonweb/exitserver/domain/theme/GenreEnum.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/theme/GenreEnum.kt
@@ -1,0 +1,8 @@
+package jsonweb.exitserver.domain.theme
+
+enum class GenreEnum(private val kor: String) {
+    HORROR("공포"),
+    MYSTERY("미스터리"),
+    ROMANCE("로맨스");
+    fun kor() = kor
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/theme/Theme.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/theme/Theme.kt
@@ -61,6 +61,8 @@ class Theme(
 
     // for test
     constructor(): this("", "", "", 0, 0, 0, 0.0, "", Cafe())
+    constructor(difficulty: Double): this("", "", "", 0, 0, 0, difficulty, "", Cafe())
+
 }
 
 @Entity

--- a/src/main/kotlin/jsonweb/exitserver/domain/theme/ThemeService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/theme/ThemeService.kt
@@ -35,7 +35,7 @@ class ThemeService(
     }
 
     fun getThemeList(cafeId: Long, sort: String): ThemeListResponse {
-        val cafe = cafeRepository.findById(cafeId).orElseThrow { throw EntityNotFoundException() }
+        val cafe = cafeRepository.findById(cafeId).orElseThrow()
         val themes = themeRepository.findAllByCafe(cafe)
         if (sort == "POPULAR") {
             sortTheme(themes)
@@ -56,26 +56,18 @@ class ThemeService(
         // TODO: update 로직 어떻게 처리할지 고민
     }
 
-    fun sortTheme(themes: List<Theme>){
-        themes.sortedWith(kotlin.Comparator { o1, o2 -> (o2.avgStar.toInt() * o2.reviewCount) - (o1.avgStar.toInt() * o1.reviewCount)})
-    }
-
-    private fun addGenre(genreList: List<String>) {
-        for (genreName in genreList) {
-            genreRepository.save(Genre(genreName))
-        }
+    fun sortTheme(themes: List<Theme>) {
+        themes.sortedWith { o1, o2 -> (o2.avgStar.toInt() * o2.reviewCount) - (o1.avgStar.toInt() * o1.reviewCount) }
     }
 
     private fun addThemeGenre(theme: Theme, genreList: List<String>) {
         for (genreName in genreList) {
             val genre = genreRepository.findGenreByGenreName(genreName)
-                .orElse(addGenre(genreName))
+                .orElse(genreRepository.save(Genre(genreName)))
             val themeGenre = themeGenreRepository.save(ThemeGenre(theme, genre))
             theme.addThemeGenre(themeGenre)
         }
     }
 
-    private fun getTheme(themeId: Long): Theme = themeRepository.findById(themeId).orElseThrow { throw EntityNotFoundException() }
-
-    private fun addGenre(genreName: String): Genre = genreRepository.save(Genre(genreName))
+    private fun getTheme(themeId: Long): Theme = themeRepository.findById(themeId).orElseThrow()
 }

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
@@ -2,6 +2,7 @@ package jsonweb.exitserver.domain.user
 
 import jsonweb.exitserver.domain.boast.Boast
 import jsonweb.exitserver.domain.inquiry.Inquiry
+import jsonweb.exitserver.domain.report.Report
 import jsonweb.exitserver.domain.review.Review
 import jsonweb.exitserver.domain.theme.GenreEnum
 import jsonweb.exitserver.util.badge.Badge
@@ -31,8 +32,8 @@ class User(
         protected set
 
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
-    protected val myBoastMutableList: MutableList<Boast> = mutableListOf()
-    val myBoastList: List<Boast> get() = myBoastMutableList.toList()
+    protected val boastMutableList: MutableList<Boast> = mutableListOf()
+    val boastList: List<Boast> get() = boastMutableList.toList()
 
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
     protected val reviewMutableList: MutableList<Review> = mutableListOf()
@@ -45,6 +46,10 @@ class User(
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
     protected val badgeMutableSet: MutableSet<Badge> = mutableSetOf()
     val badgeList: List<Badge> get() = badgeMutableSet.toList()
+
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
+    protected val reportMutableList: MutableList<Report> = mutableListOf()
+    val reportList: List<Report> get() = reportMutableList.toList()
 
 
     @Enumerated(EnumType.STRING)
@@ -107,16 +112,21 @@ class User(
 
     // boast
     fun addMyBoast(boast: Boast) {
-        myBoastMutableList.add(boast)
+        boastMutableList.add(boast)
     }
 
     fun clearMyBoast() {
-        myBoastMutableList.clear()
+        boastMutableList.clear()
     }
 
     // review
     fun addReview(review: Review) {
         reviewMutableList.add(review)
+    }
+
+    // report
+    fun addReport(report: Report) {
+        reportMutableList.add(report)
     }
 
 }

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
@@ -86,6 +86,9 @@ class User(
     fun isNotGotten(badgeEnum: BadgeEnum): Boolean = badgeMutableSet
         .none { it.badge == badgeEnum.kor() }
 
+    fun clearBadge() {
+        badgeMutableSet.clear()
+    }
     
 
     fun updateUserInfo(newNickname: String? = null, newProfileImageUrl: String? = null) {

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
@@ -122,5 +122,9 @@ class User(
         myBoastMutableList.clear()
     }
 
+    // review
+    fun addReview(review: Review) {
+        reviewMutableList.add(review)
+    }
 
 }

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
@@ -3,6 +3,7 @@ package jsonweb.exitserver.domain.user
 import jsonweb.exitserver.domain.boast.Boast
 import jsonweb.exitserver.domain.inquiry.Inquiry
 import jsonweb.exitserver.domain.review.Review
+import jsonweb.exitserver.domain.theme.GenreEnum
 import jsonweb.exitserver.util.badge.Badge
 import jsonweb.exitserver.util.badge.BadgeEnum
 import javax.persistence.*
@@ -57,15 +58,7 @@ class User(
     // user
     @PostUpdate
     fun checkUserLevel() {
-        level = if (exp >= UserLevelEnum.LEVEL_4.getNeedExp()) {
-            UserLevelEnum.LEVEL_4.getLevelName()
-        } else if (exp >= UserLevelEnum.LEVEL_3.getNeedExp()) {
-            UserLevelEnum.LEVEL_3.getLevelName()
-        } else if (exp >= UserLevelEnum.LEVEL_2.getNeedExp()) {
-            UserLevelEnum.LEVEL_2.getLevelName()
-        } else {
-            UserLevelEnum.LEVEL_1.getLevelName()
-        }
+        level = UserLevelEnum.getLevelName(exp)
     }
 
     fun addExp(amount: Int) {
@@ -75,14 +68,20 @@ class User(
     fun addBadge(badgeEnum: BadgeEnum) {
         badgeMutableSet.add(badgeEnum.toEntity(this))
     }
-    
+
+    fun getReviewGenreCount(genreEnum: GenreEnum) = reviewList
+        .filter {
+            it.theme.themeGenreList
+                .any { theme -> theme.genre.genreName == genreEnum.kor() }
+        }.size
+
     fun isNotGotten(badgeEnum: BadgeEnum): Boolean = badgeMutableSet
         .none { it.badge == badgeEnum.kor() }
 
     fun clearBadge() {
         badgeMutableSet.clear()
     }
-    
+
 
     fun updateUserInfo(newNickname: String? = null, newProfileImageUrl: String? = null) {
         newNickname?.let { nickname = newNickname }
@@ -95,7 +94,7 @@ class User(
 
     // inquiry
     fun addInquiry(inquiry: Inquiry) {
-       inquiryMutableList.add(inquiry)
+        inquiryMutableList.add(inquiry)
     }
 
     fun deleteInquiry(inquiry: Inquiry) {

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
@@ -8,14 +8,7 @@ import jsonweb.exitserver.util.badge.BadgeEnum
 import javax.persistence.*
 
 enum class Role { ROLE_USER, ROLE_ADMIN }
-enum class UserLevel(private val levelName: String, private val needExp: Int) {
-    LEVEL_1("초보", 100),
-    LEVEL_2("중수", 200),
-    LEVEL_3("고수", 300),
-    LEVEL_4("초고수", 400);
-    fun getLevelName() = levelName
-    fun getNeedExp() = needExp
-}
+
 
 @Entity
 class User(
@@ -33,7 +26,7 @@ class User(
         protected set
     var exp: Int = 0
         protected set
-    var level: String = UserLevel.LEVEL_1.getLevelName()
+    var level: String = UserLevelEnum.LEVEL_1.getLevelName()
         protected set
 
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
@@ -64,14 +57,14 @@ class User(
     // user
     @PostUpdate
     fun checkUserLevel() {
-        level = if (exp >= UserLevel.LEVEL_4.getNeedExp()) {
-            UserLevel.LEVEL_4.getLevelName()
-        } else if (exp >= UserLevel.LEVEL_3.getNeedExp()) {
-            UserLevel.LEVEL_3.getLevelName()
-        } else if (exp >= UserLevel.LEVEL_2.getNeedExp()) {
-            UserLevel.LEVEL_2.getLevelName()
+        level = if (exp >= UserLevelEnum.LEVEL_4.getNeedExp()) {
+            UserLevelEnum.LEVEL_4.getLevelName()
+        } else if (exp >= UserLevelEnum.LEVEL_3.getNeedExp()) {
+            UserLevelEnum.LEVEL_3.getLevelName()
+        } else if (exp >= UserLevelEnum.LEVEL_2.getNeedExp()) {
+            UserLevelEnum.LEVEL_2.getLevelName()
         } else {
-            UserLevel.LEVEL_1.getLevelName()
+            UserLevelEnum.LEVEL_1.getLevelName()
         }
     }
 

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
@@ -68,6 +68,10 @@ class User(
         }
     }
 
+    fun addExp(amount: Int) {
+        this.exp += amount
+    }
+
     fun updateUserInfo(newNickname: String? = null, newProfileImageUrl: String? = null) {
         newNickname?.let { nickname = newNickname }
         newProfileImageUrl?.let { profileImageUrl = newProfileImageUrl }

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/User.kt
@@ -3,6 +3,8 @@ package jsonweb.exitserver.domain.user
 import jsonweb.exitserver.domain.boast.Boast
 import jsonweb.exitserver.domain.inquiry.Inquiry
 import jsonweb.exitserver.domain.review.Review
+import jsonweb.exitserver.util.badge.Badge
+import jsonweb.exitserver.util.badge.BadgeEnum
 import javax.persistence.*
 
 enum class Role { ROLE_USER, ROLE_ADMIN }
@@ -46,6 +48,11 @@ class User(
     protected val inquiryMutableList: MutableList<Inquiry> = mutableListOf()
     val inquiryList: List<Inquiry> get() = inquiryMutableList.toList()
 
+    @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL], orphanRemoval = true)
+    protected val badgeMutableSet: MutableSet<Badge> = mutableSetOf()
+    val badgeList: List<Badge> get() = badgeMutableSet.toList()
+
+
     @Enumerated(EnumType.STRING)
     var role: Role = Role.ROLE_USER
         protected set
@@ -69,8 +76,17 @@ class User(
     }
 
     fun addExp(amount: Int) {
-        this.exp += amount
+        exp += amount
     }
+
+    fun addBadge(badgeEnum: BadgeEnum) {
+        badgeMutableSet.add(badgeEnum.toEntity(this))
+    }
+    
+    fun isNotGotten(badgeEnum: BadgeEnum): Boolean = badgeMutableSet
+        .none { it.badge == badgeEnum.kor() }
+
+    
 
     fun updateUserInfo(newNickname: String? = null, newProfileImageUrl: String? = null) {
         newNickname?.let { nickname = newNickname }

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/UserLevelEnum.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/UserLevelEnum.kt
@@ -1,0 +1,10 @@
+package jsonweb.exitserver.domain.user
+
+enum class UserLevelEnum(private val levelName: String, private val needExp: Int) {
+    LEVEL_1("탈출노비", 100),
+    LEVEL_2("탈출평민", 200),
+    LEVEL_3("탈출양반", 300),
+    LEVEL_4("탈출왕", 400);
+    fun getLevelName() = levelName
+    fun getNeedExp() = needExp
+}

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/UserLevelEnum.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/UserLevelEnum.kt
@@ -6,5 +6,19 @@ enum class UserLevelEnum(private val levelName: String, private val needExp: Int
     LEVEL_3("탈출양반", 300),
     LEVEL_4("탈출왕", 400);
     fun getLevelName() = levelName
-    fun getNeedExp() = needExp
+
+    companion object {
+        @JvmStatic
+        fun getLevelName(exp: Int): String {
+            return if (exp >= LEVEL_4.needExp) {
+                LEVEL_4.levelName
+            } else if (exp >= LEVEL_3.needExp) {
+                LEVEL_3.levelName
+            } else if (exp >= LEVEL_2.needExp) {
+                LEVEL_2.levelName
+            } else {
+                LEVEL_1.levelName
+            }
+        }
+    }
 }

--- a/src/main/kotlin/jsonweb/exitserver/domain/user/UserService.kt
+++ b/src/main/kotlin/jsonweb/exitserver/domain/user/UserService.kt
@@ -4,8 +4,6 @@ import jsonweb.exitserver.auth.KakaoClient
 import jsonweb.exitserver.auth.jwt.JwtProvider
 import jsonweb.exitserver.auth.security.getCurrentLoginUserId
 import jsonweb.exitserver.common.TEST_ADMIN_KAKAO_ID
-import jsonweb.exitserver.common.USER_NOT_FOUND
-import jsonweb.exitserver.common.UserException
 import jsonweb.exitserver.util.NicknameGenerator
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
@@ -22,9 +20,9 @@ class UserService(
     private val passwordEncoder: BCryptPasswordEncoder,
     private val nicknameGenerator: NicknameGenerator
 ) {
-
-    fun getCurrentLoginUser(): User = userRepository.findById(getCurrentLoginUserId())
-        .orElseThrow { UserException(USER_NOT_FOUND) }
+    fun getCurrentLoginUser(): User = userRepository
+        .findById(getCurrentLoginUserId())
+        .orElseThrow()
 
     fun getCurrentLoginUserToDto() = UserInfoResponse(getCurrentLoginUser())
 

--- a/src/main/kotlin/jsonweb/exitserver/util/ExpAspect.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/ExpAspect.kt
@@ -1,0 +1,25 @@
+package jsonweb.exitserver.util
+
+import jsonweb.exitserver.domain.user.UserService
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.springframework.stereotype.Component
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Exp (
+    val amount: Int = 0
+)
+
+@Aspect
+@Component
+class ExpAspect(private val userService: UserService) {
+    @AfterReturning("@annotation(jsonweb.exitserver.util.Exp)")
+    fun addExp(joinPoint: JoinPoint) {
+        val signature = joinPoint.signature as MethodSignature
+        val amount = signature.method.getAnnotation(Exp::class.java).amount
+        userService.getCurrentLoginUser().addExp(amount)
+    }
+}

--- a/src/main/kotlin/jsonweb/exitserver/util/StringDateFormatters.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/StringDateFormatters.kt
@@ -1,3 +1,6 @@
 package jsonweb.exitserver.util
 
-fun String.toDotFormat() = this.replace("-", ".")
+fun String.toDotFormat() = this
+    .split(" ")[0]
+    .replace("-", ".")
+

--- a/src/main/kotlin/jsonweb/exitserver/util/badge/Badge.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/badge/Badge.kt
@@ -16,39 +16,3 @@ class Badge(
     val badge: String,
 ) : BaseTimeEntity()
 
-enum class BadgeEnum(private val kor: String, private val requirement: String) {
-    EIXTER(
-        "엑시터", "첫 리뷰 작성"
-    ),
-
-    ADDICTED_ESCAPE(
-        "탈출중독", "인증 10개 이상 작성"
-    ),
-
-    TREND_SETTER(
-        "트렌드세터", "카페 등록 요청 5번 승낙"
-    ),
-
-    EXIT_SHERIFF(
-        "엑시트 보안관", "리뷰 신고 10번 처리 됨"
-    ),
-
-    HIGHEST_REALM(
-        "천상계", "난이도 5 탈출 인증"
-    ),
-
-    HORROR_MANIA(
-        "공포매니아", "공포 장르 리뷰 3개 작성"
-    ),
-
-    MYSTERY_LOVER(
-        "미스터리 러버", "미스터리 장르 리뷰 3개 작성"
-    ),
-
-    ROMANCE_HOLIC(
-        "로맨스 홀릭", "로맨스 장르 리뷰 3개 작성"
-    );
-    fun toEntity(user: User) = Badge(user = user, badge = kor)
-    fun kor() = kor
-    fun requirement() = requirement
-}

--- a/src/main/kotlin/jsonweb/exitserver/util/badge/Badge.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/badge/Badge.kt
@@ -1,0 +1,54 @@
+package jsonweb.exitserver.util.badge
+
+import jsonweb.exitserver.common.BaseTimeEntity
+import jsonweb.exitserver.domain.user.User
+import javax.persistence.*
+
+@Entity
+class Badge(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val badgeId: Long = 0L,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User,
+
+    val badge: String,
+) : BaseTimeEntity()
+
+enum class BadgeEnum(private val kor: String, private val requirement: String) {
+    EIXTER(
+        "엑시터", "첫 리뷰 작성"
+    ),
+
+    ADDICTED_ESCAPE(
+        "탈출중독", "인증 10개 이상 작성"
+    ),
+
+    TREND_SETTER(
+        "트렌드세터", "카페 등록 요청 5번 승낙"
+    ),
+
+    EXIT_SHERIFF(
+        "엑시트 보안관", "리뷰 신고 10번 처리 됨"
+    ),
+
+    HIGHEST_REALM(
+        "천상계", "난이도 5 탈출 인증"
+    ),
+
+    HORROR_MANIA(
+        "공포매니아", "공포 장르 리뷰 3개 작성"
+    ),
+
+    MYSTERY_LOVER(
+        "미스터리 러버", "미스터리 장르 리뷰 3개 작성"
+    ),
+
+    ROMANCE_HOLIC(
+        "로맨스 홀릭", "로맨스 장르 리뷰 3개 작성"
+    );
+    fun toEntity(user: User) = Badge(user = user, badge = kor)
+    fun kor() = kor
+    fun requirement() = requirement
+}

--- a/src/main/kotlin/jsonweb/exitserver/util/badge/BadgeEnum.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/badge/BadgeEnum.kt
@@ -1,0 +1,40 @@
+package jsonweb.exitserver.util.badge
+
+import jsonweb.exitserver.domain.user.User
+
+enum class BadgeEnum(private val kor: String, private val requirement: String) {
+    EIXTER(
+        "엑시터", "첫 리뷰 작성"
+    ),
+
+    ADDICTED_ESCAPE(
+        "탈출중독", "인증 10개 이상 작성"
+    ),
+
+    TREND_SETTER(
+        "트렌드세터", "카페 등록 요청 5번 승낙"
+    ),
+
+    EXIT_SHERIFF(
+        "엑시트 보안관", "리뷰 신고 10번 처리 됨"
+    ),
+
+    HIGHEST_REALM(
+        "천상계", "난이도 5 탈출 인증"
+    ),
+
+    HORROR_MANIA(
+        "공포매니아", "공포 장르 리뷰 3개 작성"
+    ),
+
+    MYSTERY_LOVER(
+        "미스터리 러버", "미스터리 장르 리뷰 3개 작성"
+    ),
+
+    ROMANCE_HOLIC(
+        "로맨스 홀릭", "로맨스 장르 리뷰 3개 작성"
+    );
+    fun toEntity(user: User) = Badge(user = user, badge = kor)
+    fun kor() = kor
+    fun requirement() = requirement
+}

--- a/src/main/kotlin/jsonweb/exitserver/util/badge/BadgeEnum.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/badge/BadgeEnum.kt
@@ -2,6 +2,8 @@ package jsonweb.exitserver.util.badge
 
 import jsonweb.exitserver.domain.user.User
 
+const val GENRE_REVIEW_REQUIREMENT = 3
+
 enum class BadgeEnum(private val kor: String, private val requirement: String) {
     EIXTER(
         "엑시터", "첫 리뷰 작성"

--- a/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
@@ -1,22 +1,24 @@
 package jsonweb.exitserver.util.badge
 
 import jsonweb.exitserver.common.logger
+import jsonweb.exitserver.domain.inquiry.InquiryStatus
+import jsonweb.exitserver.domain.theme.GenreEnum
+import jsonweb.exitserver.domain.user.User
 import jsonweb.exitserver.domain.user.UserService
 import org.aspectj.lang.JoinPoint
 import org.aspectj.lang.annotation.AfterReturning
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.reflect.MethodSignature
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 
-enum class BadgeType {
+enum class BadgeDomain {
     BOAST, INQUIRY, REVIEW
 }
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class CheckBadge(
-    val type: BadgeType
+    val type: BadgeDomain
 )
 
 @Aspect
@@ -27,31 +29,80 @@ class CheckBadgeAspect(private val userService: UserService) {
     @AfterReturning("@annotation(jsonweb.exitserver.util.badge.CheckBadge)")
     fun checkBadge(joinPoint: JoinPoint) {
         val signature = joinPoint.signature as MethodSignature
+        val user = userService.getCurrentLoginUser()
         when (signature.method.getAnnotation(CheckBadge::class.java).type) {
-            BadgeType.BOAST -> checkBoastBadge()
-            else -> {}
+            BadgeDomain.BOAST -> checkBoastBadge(user)
+            BadgeDomain.REVIEW -> checkReviewBadge(user)
+            BadgeDomain.INQUIRY -> checkInquiryBadge(user)
         }
-
     }
 
-    @Transactional
-    fun checkBoastBadge() {
-        val user = userService.getCurrentLoginUser()
-
-        // 인증 글 10개 작성 시 탈출중독 뱃지 획득
+    private fun checkBoastBadge(user: User) {
+        // 인증 글 10개 작성, 탈출중독
         if (user.isNotGotten(BadgeEnum.ADDICTED_ESCAPE) &&
             user.myBoastList.size == 10
         ) {
-            log.info("${user.nickname}님이 탈출중독 뱃지 획득.")
+            log.info("${user.nickname}님이 ${BadgeEnum.ADDICTED_ESCAPE.kor()} 뱃지 획득!")
             user.addBadge(BadgeEnum.ADDICTED_ESCAPE)
         }
 
-        // 난이도 5 탈출 인증 시 천상계 뱃지 획득
+        // 첫 난이도 5 탈출 인증 작성, 천상계
         if (user.isNotGotten(BadgeEnum.HIGHEST_REALM) &&
             user.myBoastList.any { it.theme.difficulty == 5.0 }
         ) {
-            log.info("${user.nickname}님이 천상계 뱃지 획득.")
+            log.info("${user.nickname}님이 ${BadgeEnum.HIGHEST_REALM.kor()} 뱃지 획득!")
             user.addBadge(BadgeEnum.HIGHEST_REALM)
+        }
+    }
+
+    private fun setGenreBadge(genre: GenreEnum, badge: BadgeEnum) {
+        val user = userService.getCurrentLoginUser()
+        val genreCount = user.reviewList
+            .filter { it.theme.themeGenreList
+                .any { theme -> theme.genre.genreName == genre.kor() }
+            }.size
+        if (user.isNotGotten(badge) &&
+            genreCount == 3
+        ) {
+            log.info("${user.nickname}님이 ${genre.kor()} 뱃지 획득!")
+            user.addBadge(badge)
+        }
+    }
+
+    private fun checkReviewBadge(user: User) {
+        // 첫 리뷰, 엑시터
+        if (user.isNotGotten(BadgeEnum.EIXTER) &&
+            user.reviewList.size == 1
+        ) {
+            log.info("${user.nickname}님이 ${BadgeEnum.EIXTER.kor()} 뱃지 획득!")
+            user.addBadge(BadgeEnum.EIXTER)
+        }
+
+        // 공포 장르 리뷰 3개 작성, 공포매니아
+        setGenreBadge(GenreEnum.HORROR, BadgeEnum.HORROR_MANIA)
+
+        // 미스터리 장르 리뷰 3개 작성, 미스터리 러버
+        setGenreBadge(GenreEnum.MYSTERY, BadgeEnum.MYSTERY_LOVER)
+
+        // 로맨스 장르 리뷰 3개 작성, 로맨스 홀릭
+        setGenreBadge(GenreEnum.ROMANCE, BadgeEnum.ROMANCE_HOLIC)
+
+        // TODO : 리뷰 신고 10개 처리, 엑시트 보안관
+
+    }
+
+    private fun checkInquiryBadge(user: User) {
+        // 카페 등록 요청 5번 승낙, 트렌드세터
+        val condition = user.inquiryList
+            .filter { it.status == InquiryStatus.RESOLVED }
+            .filter { it.category == "카페 등록 문의" }
+            .size
+
+        if (user.isNotGotten(BadgeEnum.TREND_SETTER) &&
+            condition == 5
+        ) {
+            log.info("${user.nickname}님이 ${BadgeEnum.TREND_SETTER.kor()} 뱃지 획득!")
+            user.addBadge(BadgeEnum.TREND_SETTER)
         }
     }
 

--- a/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
@@ -1,7 +1,7 @@
 package jsonweb.exitserver.util.badge
 
 import jsonweb.exitserver.common.logger
-import jsonweb.exitserver.domain.inquiry.InquiryStatus
+import jsonweb.exitserver.domain.inquiry.InquiryCategoryEnum
 import jsonweb.exitserver.domain.theme.GenreEnum
 import jsonweb.exitserver.domain.user.User
 import jsonweb.exitserver.domain.user.UserService
@@ -92,10 +92,9 @@ class CheckBadgeAspect(private val userService: UserService) {
     }
 
     private fun checkInquiryBadge(user: User) {
-        // 카페 등록 요청 5번 승낙, 트렌드세터
+        // 카페 등록 요청 5번 등록 요청, 트렌드세터
         val condition = user.inquiryList
-            .filter { it.status == InquiryStatus.RESOLVED }
-            .filter { it.category == "카페 등록 문의" }
+            .filter { it.category == InquiryCategoryEnum.CAFE.kor() }
             .size
 
         if (user.isNotGotten(BadgeEnum.TREND_SETTER) &&

--- a/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
@@ -1,0 +1,58 @@
+package jsonweb.exitserver.util.badge
+
+import jsonweb.exitserver.common.logger
+import jsonweb.exitserver.domain.user.UserService
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.AfterReturning
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+enum class BadgeType {
+    BOAST, INQUIRY, REVIEW
+}
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class CheckBadge(
+    val type: BadgeType
+)
+
+@Aspect
+@Component
+class CheckBadgeAspect(private val userService: UserService) {
+    val log = logger()
+
+    @AfterReturning("@annotation(jsonweb.exitserver.util.badge.CheckBadge)")
+    fun checkBadge(joinPoint: JoinPoint) {
+        val signature = joinPoint.signature as MethodSignature
+        when (signature.method.getAnnotation(CheckBadge::class.java).type) {
+            BadgeType.BOAST -> checkBoastBadge()
+            else -> {}
+        }
+
+    }
+
+    @Transactional
+    fun checkBoastBadge() {
+        val user = userService.getCurrentLoginUser()
+
+        // 인증 글 10개 작성 시 탈출중독 뱃지 획득
+        if (user.isNotGotten(BadgeEnum.ADDICTED_ESCAPE) &&
+            user.myBoastList.size == 10
+        ) {
+            log.info("${user.nickname}님이 탈출중독 뱃지 획득.")
+            user.addBadge(BadgeEnum.ADDICTED_ESCAPE)
+        }
+
+        // 난이도 5 탈출 인증 시 천상계 뱃지 획득
+        if (user.isNotGotten(BadgeEnum.HIGHEST_REALM) &&
+            user.myBoastList.any { it.theme.difficulty == 5.0 }
+        ) {
+            log.info("${user.nickname}님이 천상계 뱃지 획득.")
+            user.addBadge(BadgeEnum.HIGHEST_REALM)
+        }
+    }
+
+}

--- a/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
@@ -29,6 +29,7 @@ class CheckBadgeAspect(private val userService: UserService) {
     @AfterReturning("@annotation(jsonweb.exitserver.util.badge.CheckBadge)")
     fun checkBadge(joinPoint: JoinPoint) {
         val signature = joinPoint.signature as MethodSignature
+        val params = signature.parameterNames
         val user = userService.getCurrentLoginUser()
         when (signature.method.getAnnotation(CheckBadge::class.java).type) {
             BadgeDomain.BOAST -> checkBoastBadge(user)
@@ -55,20 +56,6 @@ class CheckBadgeAspect(private val userService: UserService) {
         }
     }
 
-    private fun setGenreBadge(genre: GenreEnum, badge: BadgeEnum) {
-        val user = userService.getCurrentLoginUser()
-        val genreCount = user.reviewList
-            .filter { it.theme.themeGenreList
-                .any { theme -> theme.genre.genreName == genre.kor() }
-            }.size
-        if (user.isNotGotten(badge) &&
-            genreCount == 3
-        ) {
-            log.info("${user.nickname}님이 ${badge.kor()} 뱃지 획득!")
-            user.addBadge(badge)
-        }
-    }
-
     private fun checkReviewBadge(user: User) {
         // 첫 리뷰, 엑시터
         if (user.isNotGotten(BadgeEnum.EIXTER) &&
@@ -79,16 +66,30 @@ class CheckBadgeAspect(private val userService: UserService) {
         }
 
         // 공포 장르 리뷰 3개 작성, 공포매니아
-        setGenreBadge(GenreEnum.HORROR, BadgeEnum.HORROR_MANIA)
+        if (user.isNotGotten(BadgeEnum.HORROR_MANIA) &&
+            user.getReviewGenreCount(GenreEnum.HORROR) == GENRE_REVIEW_REQUIREMENT
+        ) {
+            log.info("${user.nickname}님이 ${BadgeEnum.HORROR_MANIA.kor()} 뱃지 획득!")
+            user.addBadge(BadgeEnum.HORROR_MANIA)
+        }
 
         // 미스터리 장르 리뷰 3개 작성, 미스터리 러버
-        setGenreBadge(GenreEnum.MYSTERY, BadgeEnum.MYSTERY_LOVER)
+        if (user.isNotGotten(BadgeEnum.MYSTERY_LOVER) &&
+            user.getReviewGenreCount(GenreEnum.MYSTERY) == GENRE_REVIEW_REQUIREMENT
+        ) {
+            log.info("${user.nickname}님이 ${BadgeEnum.MYSTERY_LOVER.kor()} 뱃지 획득!")
+            user.addBadge(BadgeEnum.MYSTERY_LOVER)
+        }
 
         // 로맨스 장르 리뷰 3개 작성, 로맨스 홀릭
-        setGenreBadge(GenreEnum.ROMANCE, BadgeEnum.ROMANCE_HOLIC)
+        if (user.isNotGotten(BadgeEnum.ROMANCE_HOLIC) &&
+            user.getReviewGenreCount(GenreEnum.ROMANCE) == GENRE_REVIEW_REQUIREMENT
+        ) {
+            log.info("${user.nickname}님이 ${BadgeEnum.ROMANCE_HOLIC.kor()} 뱃지 획득!")
+            user.addBadge(BadgeEnum.ROMANCE_HOLIC)
+        }
 
         // TODO : 리뷰 신고 10개 처리, 엑시트 보안관
-
     }
 
     private fun checkInquiryBadge(user: User) {

--- a/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
@@ -2,6 +2,7 @@ package jsonweb.exitserver.util.badge
 
 import jsonweb.exitserver.common.logger
 import jsonweb.exitserver.domain.inquiry.InquiryCategoryEnum
+import jsonweb.exitserver.domain.report.ReviewReport
 import jsonweb.exitserver.domain.theme.GenreEnum
 import jsonweb.exitserver.domain.user.User
 import jsonweb.exitserver.domain.user.UserService
@@ -41,7 +42,7 @@ class CheckBadgeAspect(private val userService: UserService) {
     private fun checkBoastBadge(user: User) {
         // 인증 글 10개 작성, 탈출중독
         if (user.isNotGotten(BadgeEnum.ADDICTED_ESCAPE) &&
-            user.myBoastList.size == 10
+            user.boastList.size == 10
         ) {
             log.info("${user.nickname}님이 ${BadgeEnum.ADDICTED_ESCAPE.kor()} 뱃지 획득!")
             user.addBadge(BadgeEnum.ADDICTED_ESCAPE)
@@ -49,7 +50,7 @@ class CheckBadgeAspect(private val userService: UserService) {
 
         // 첫 난이도 5 탈출 인증 작성, 천상계
         if (user.isNotGotten(BadgeEnum.HIGHEST_REALM) &&
-            user.myBoastList.any { it.theme.difficulty == 5.0 }
+            user.boastList.any { it.theme.difficulty == 5.0 }
         ) {
             log.info("${user.nickname}님이 ${BadgeEnum.HIGHEST_REALM.kor()} 뱃지 획득!")
             user.addBadge(BadgeEnum.HIGHEST_REALM)
@@ -89,7 +90,13 @@ class CheckBadgeAspect(private val userService: UserService) {
             user.addBadge(BadgeEnum.ROMANCE_HOLIC)
         }
 
-        // TODO : 리뷰 신고 10개 처리, 엑시트 보안관
+        // 리뷰 신고 10개 작성, 엑시트 보안관
+        if (user.isNotGotten(BadgeEnum.EXIT_SHERIFF) &&
+            user.reportList.filterIsInstance<ReviewReport>().size == 10
+        ) {
+            log.info("${user.nickname}님이 ${BadgeEnum.EXIT_SHERIFF.kor()} 뱃지 획득!")
+            user.addBadge(BadgeEnum.EXIT_SHERIFF)
+        }
     }
 
     private fun checkInquiryBadge(user: User) {

--- a/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
+++ b/src/main/kotlin/jsonweb/exitserver/util/badge/CheckBadgeAspect.kt
@@ -64,7 +64,7 @@ class CheckBadgeAspect(private val userService: UserService) {
         if (user.isNotGotten(badge) &&
             genreCount == 3
         ) {
-            log.info("${user.nickname}님이 ${genre.kor()} 뱃지 획득!")
+            log.info("${user.nickname}님이 ${badge.kor()} 뱃지 획득!")
             user.addBadge(badge)
         }
     }

--- a/src/test/kotlin/jsonweb/exitserver/domain/MockUtils.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/MockUtils.kt
@@ -7,10 +7,12 @@ import jsonweb.exitserver.domain.theme.Theme
 import jsonweb.exitserver.domain.theme.ThemeGenre
 import jsonweb.exitserver.domain.user.User
 
-val mockUser = User(-1, "pwd", "male", "20~29", "랜덤 닉네임")
-val mockTheme = Theme()
-val mockReview = Review("", 3.0, 3.0, "", "", mockUser, mockTheme)
 
+fun getMockUser() = User(-1, "pwd", "male", "20~29", "랜덤 닉네임")
+fun getMockReview() = Review("", 3.0, 3.0, "", "", getMockUser(), Theme())
 
-
-
+fun getMockReview(genreEnum: GenreEnum): Review {
+    val theme = Theme()
+    theme.addThemeGenre(ThemeGenre(theme, Genre(genreEnum.kor())))
+    return Review("", 3.0, 3.0, "", "", getMockUser(), theme)
+}

--- a/src/test/kotlin/jsonweb/exitserver/domain/MockUtils.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/MockUtils.kt
@@ -1,0 +1,16 @@
+package jsonweb.exitserver.domain
+
+import jsonweb.exitserver.domain.review.Review
+import jsonweb.exitserver.domain.theme.Genre
+import jsonweb.exitserver.domain.theme.GenreEnum
+import jsonweb.exitserver.domain.theme.Theme
+import jsonweb.exitserver.domain.theme.ThemeGenre
+import jsonweb.exitserver.domain.user.User
+
+val mockUser = User(-1, "pwd", "male", "20~29", "랜덤 닉네임")
+val mockTheme = Theme()
+val mockReview = Review("", 3.0, 3.0, "", "", mockUser, mockTheme)
+
+
+
+

--- a/src/test/kotlin/jsonweb/exitserver/domain/badge/BoastBadgeTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/badge/BoastBadgeTest.kt
@@ -8,8 +8,7 @@ import jsonweb.exitserver.domain.boast.Boast
 import jsonweb.exitserver.domain.boast.BoastRepository
 import jsonweb.exitserver.domain.boast.BoastRequest
 import jsonweb.exitserver.domain.boast.BoastService
-import jsonweb.exitserver.domain.mockTheme
-import jsonweb.exitserver.domain.mockUser
+import jsonweb.exitserver.domain.getMockUser
 import jsonweb.exitserver.domain.theme.Theme
 import jsonweb.exitserver.domain.theme.ThemeRepository
 import jsonweb.exitserver.domain.user.UserService
@@ -29,6 +28,9 @@ class BoastBadgeTest : AnnotationSpec() {
         mockk(),
         mockk()
     )
+
+    private val mockUser = getMockUser()
+    private val mockTheme = Theme()
 
     private lateinit var factory: AspectJProxyFactory
     private lateinit var boastServiceProxy: BoastService

--- a/src/test/kotlin/jsonweb/exitserver/domain/badge/BoastBadgeTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/badge/BoastBadgeTest.kt
@@ -26,7 +26,7 @@ class BoastBadgeTest : AnnotationSpec() {
         themeRepository,
         boastRepository,
         mockk(),
-        mockk()
+//        mockk()
     )
 
     private val mockUser = getMockUser()

--- a/src/test/kotlin/jsonweb/exitserver/domain/badge/BoastBadgeTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/badge/BoastBadgeTest.kt
@@ -1,0 +1,86 @@
+package jsonweb.exitserver.domain.badge
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import jsonweb.exitserver.domain.boast.*
+import jsonweb.exitserver.domain.theme.Theme
+import jsonweb.exitserver.domain.theme.ThemeRepository
+import jsonweb.exitserver.domain.user.User
+import jsonweb.exitserver.domain.user.UserService
+import jsonweb.exitserver.util.badge.BadgeEnum
+import jsonweb.exitserver.util.badge.CheckBadgeAspect
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory
+import java.util.*
+
+class BoastBadgeTest : AnnotationSpec() {
+    private val userService: UserService = mockk()
+    private val themeRepository: ThemeRepository = mockk()
+    private val boastRepository: BoastRepository = mockk()
+    private val boastLikeRepository: BoastLikeRepository = mockk()
+    private val boastReportRepository: BoastReportRepository = mockk()
+
+    private val boastService: BoastService = spyk(
+        BoastService(userService, themeRepository, boastRepository, boastLikeRepository, boastReportRepository),
+        recordPrivateCalls = true
+    )
+
+    private val mockUser = User(-1, "pwd", "male", "20~29", "랜덤 닉네임")
+    private val mockTheme = Theme()
+
+    private lateinit var factory: AspectJProxyFactory
+    private lateinit var boastServiceProxy: BoastService
+
+    @BeforeAll
+    fun stub() {
+        every { userService.getCurrentLoginUser() } returns mockUser
+        every { themeRepository.findById(any()) } returns Optional.of(mockTheme)
+        every { boastRepository.save(any()) } returns Boast(user = mockUser, theme = mockTheme, imageUrl = "")
+
+        factory = AspectJProxyFactory(boastService)
+        factory.addAspect(CheckBadgeAspect(userService))
+        boastServiceProxy = factory.getProxy()
+    }
+
+    @AfterEach
+    fun clear() {
+        mockUser.clearMyBoast()
+        mockUser.clearBadge()
+        print(mockUser.badgeList)
+    }
+
+    @Test
+    fun `탈출중독 - 인증 10개 작성`() {
+        // given
+        val form = BoastRequest(1L, "https://image.com/1", listOf("내용"))
+
+        // when
+        repeat(10) {
+            boastServiceProxy.createBoast(form)
+        }
+
+        // then
+        mockUser.badgeList.any {
+            it.badge == BadgeEnum.ADDICTED_ESCAPE.kor()
+        } shouldBe true
+    }
+
+    @Test
+    fun `천상계 - 난이도 5이상 테마 인증 최초 작성`() {
+        // given
+        val hardTheme = Theme(difficulty = 5.0)
+        every { themeRepository.findById(any()) } returns Optional.of(hardTheme)
+        every { boastRepository.save(any()) } returns Boast(user = mockUser, theme = hardTheme, imageUrl = "")
+        val form = BoastRequest(1L, "https://image.com/1", listOf("내용"))
+
+        // when
+        boastServiceProxy.createBoast(form)
+
+        // then
+        mockUser.badgeList.any {
+            it.badge == BadgeEnum.HIGHEST_REALM.kor()
+        } shouldBe true
+    }
+}

--- a/src/test/kotlin/jsonweb/exitserver/domain/badge/InquiryBadgeTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/badge/InquiryBadgeTest.kt
@@ -1,0 +1,56 @@
+package jsonweb.exitserver.domain.badge
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import jsonweb.exitserver.domain.getMockUser
+import jsonweb.exitserver.domain.inquiry.InquiryCategoryEnum
+import jsonweb.exitserver.domain.inquiry.InquiryRepository
+import jsonweb.exitserver.domain.inquiry.InquiryRequest
+import jsonweb.exitserver.domain.inquiry.InquiryService
+import jsonweb.exitserver.domain.user.UserService
+import jsonweb.exitserver.util.badge.BadgeEnum
+import jsonweb.exitserver.util.badge.CheckBadgeAspect
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory
+
+class InquiryBadgeTest : AnnotationSpec() {
+    private val userService: UserService = mockk()
+    private val inquiryRepository: InquiryRepository = mockk()
+
+    private val inquiryService = InquiryService(
+        userService, inquiryRepository
+    )
+
+    private val mockUser = getMockUser()
+
+    private lateinit var factory: AspectJProxyFactory
+    private lateinit var inquiryServiceProxy: InquiryService
+
+    @BeforeAll
+    fun init() {
+        every { userService.getCurrentLoginUser() } returns mockUser
+        justRun { inquiryRepository.flush() }
+
+        factory = AspectJProxyFactory(inquiryService)
+        factory.addAspect(CheckBadgeAspect(userService))
+        inquiryServiceProxy = factory.getProxy()
+    }
+
+    @Test
+    fun `트렌드세터 - 카페 등록 요청 5번`() {
+        // given
+        val form = InquiryRequest(InquiryCategoryEnum.CAFE.kor(), "", "")
+
+        // when
+        repeat(5) {
+            inquiryServiceProxy.createInquiry(form)
+        }
+
+        // then
+        mockUser.badgeList.any {
+            it.badge == BadgeEnum.TREND_SETTER.kor()
+        } shouldBe true
+    }
+}

--- a/src/test/kotlin/jsonweb/exitserver/domain/badge/ReviewBadgeTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/badge/ReviewBadgeTest.kt
@@ -1,0 +1,123 @@
+package jsonweb.exitserver.domain.badge
+
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import jsonweb.exitserver.domain.mockReview
+import jsonweb.exitserver.domain.mockTheme
+import jsonweb.exitserver.domain.mockUser
+import jsonweb.exitserver.domain.review.CreateReviewRequest
+import jsonweb.exitserver.domain.review.Review
+import jsonweb.exitserver.domain.review.ReviewService
+import jsonweb.exitserver.domain.theme.*
+import jsonweb.exitserver.domain.user.UserService
+import jsonweb.exitserver.util.badge.BadgeEnum
+import jsonweb.exitserver.util.badge.CheckBadgeAspect
+import org.modelmapper.ModelMapper
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory
+import java.util.*
+
+class ReviewBadgeTest : AnnotationSpec() {
+    private val userService: UserService = mockk()
+    private val themeRepository: ThemeRepository = mockk()
+    private val modelMapper: ModelMapper = mockk()
+
+    private val reviewService = ReviewService(
+        mockk(),
+        mockk(),
+        themeRepository,
+        userService,
+        modelMapper
+    )
+
+    private lateinit var factory: AspectJProxyFactory
+    private lateinit var reviewServiceProxy: ReviewService
+
+    @BeforeAll
+    fun init() {
+        every { modelMapper.map(any(), any<Class<*>>()) } returns mockReview
+        every { userService.getCurrentLoginUser() } returns mockUser
+        every { themeRepository.findById(any()) } returns Optional.of(mockTheme)
+
+        factory = AspectJProxyFactory(reviewService)
+        factory.addAspect(CheckBadgeAspect(userService))
+        reviewServiceProxy = factory.getProxy()
+    }
+
+    @Test
+    fun `엑시터 - 첫 리뷰 작성`() {
+        // given
+        val form = CreateReviewRequest("", "", 1.0, 1.0, "")
+
+        // when
+        reviewServiceProxy.createReview(1L, form)
+
+        // then
+        mockUser.badgeList.any {
+            it.badge == BadgeEnum.EIXTER.kor()
+        } shouldBe true
+    }
+
+    @Test
+    fun `공포매니아 - 공포 장르 리뷰 3개 작성`() {
+        // given
+        val theme = Theme()
+        theme.addThemeGenre(ThemeGenre(mockTheme, Genre(GenreEnum.HORROR.kor())))
+        val review = Review("", 3.0, 3.0, "", "", mockUser, theme)
+        every { modelMapper.map(any(), any<Class<*>>()) } returns review
+        val form = CreateReviewRequest("", "", 1.0, 1.0, "")
+
+        // when
+        repeat(3) {
+            reviewServiceProxy.createReview(1L, form)
+        }
+
+        // then
+        mockUser.badgeList.any {
+            it.badge == BadgeEnum.HORROR_MANIA.kor()
+        } shouldBe true
+    }
+
+    @Test
+    fun `미스터리러버 - 미스터리 장르 리뷰 3개 작성`() {
+        // given
+        val theme = Theme()
+        theme.addThemeGenre(ThemeGenre(mockTheme, Genre(GenreEnum.MYSTERY.kor())))
+        val review = Review("", 3.0, 3.0, "", "", mockUser, theme)
+        every { modelMapper.map(any(), any<Class<*>>()) } returns review
+        val form = CreateReviewRequest("", "", 1.0, 1.0, "")
+
+        // when
+        repeat(3) {
+            reviewServiceProxy.createReview(1L, form)
+        }
+
+        // then
+        mockUser.badgeList.any {
+            it.badge == BadgeEnum.MYSTERY_LOVER.kor()
+        } shouldBe true
+    }
+
+    @Test
+    fun `로맨스홀릭 - 로맨스 장르 리뷰 3개 작성`() {
+        // given
+        val theme = Theme()
+        theme.addThemeGenre(ThemeGenre(mockTheme, Genre(GenreEnum.ROMANCE.kor())))
+        val review = Review("", 3.0, 3.0, "", "", mockUser, theme)
+        every { modelMapper.map(any(), any<Class<*>>()) } returns review
+        val form = CreateReviewRequest("", "", 1.0, 1.0, "")
+
+        // when
+        repeat(3) {
+            reviewServiceProxy.createReview(1L, form)
+        }
+
+        // then
+        mockUser.badgeList.any {
+            it.badge == BadgeEnum.ROMANCE_HOLIC.kor()
+        } shouldBe true
+    }
+
+    // TODO : 엑시트보안관
+}

--- a/src/test/kotlin/jsonweb/exitserver/domain/badge/ReviewBadgeTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/badge/ReviewBadgeTest.kt
@@ -4,9 +4,8 @@ import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import jsonweb.exitserver.domain.mockReview
-import jsonweb.exitserver.domain.mockTheme
-import jsonweb.exitserver.domain.mockUser
+import jsonweb.exitserver.domain.getMockReview
+import jsonweb.exitserver.domain.getMockUser
 import jsonweb.exitserver.domain.review.CreateReviewRequest
 import jsonweb.exitserver.domain.review.Review
 import jsonweb.exitserver.domain.review.ReviewService
@@ -30,6 +29,10 @@ class ReviewBadgeTest : AnnotationSpec() {
         userService,
         modelMapper
     )
+
+    private val mockUser = getMockUser()
+    private val mockReview = getMockReview()
+    private val mockTheme = Theme()
 
     private lateinit var factory: AspectJProxyFactory
     private lateinit var reviewServiceProxy: ReviewService
@@ -62,10 +65,7 @@ class ReviewBadgeTest : AnnotationSpec() {
     @Test
     fun `공포매니아 - 공포 장르 리뷰 3개 작성`() {
         // given
-        val theme = Theme()
-        theme.addThemeGenre(ThemeGenre(mockTheme, Genre(GenreEnum.HORROR.kor())))
-        val review = Review("", 3.0, 3.0, "", "", mockUser, theme)
-        every { modelMapper.map(any(), any<Class<*>>()) } returns review
+        every { modelMapper.map(any(), any<Class<*>>()) } returns getMockReview(GenreEnum.HORROR)
         val form = CreateReviewRequest("", "", 1.0, 1.0, "")
 
         // when
@@ -82,10 +82,7 @@ class ReviewBadgeTest : AnnotationSpec() {
     @Test
     fun `미스터리러버 - 미스터리 장르 리뷰 3개 작성`() {
         // given
-        val theme = Theme()
-        theme.addThemeGenre(ThemeGenre(mockTheme, Genre(GenreEnum.MYSTERY.kor())))
-        val review = Review("", 3.0, 3.0, "", "", mockUser, theme)
-        every { modelMapper.map(any(), any<Class<*>>()) } returns review
+        every { modelMapper.map(any(), any<Class<*>>()) } returns getMockReview(GenreEnum.MYSTERY)
         val form = CreateReviewRequest("", "", 1.0, 1.0, "")
 
         // when
@@ -102,10 +99,7 @@ class ReviewBadgeTest : AnnotationSpec() {
     @Test
     fun `로맨스홀릭 - 로맨스 장르 리뷰 3개 작성`() {
         // given
-        val theme = Theme()
-        theme.addThemeGenre(ThemeGenre(mockTheme, Genre(GenreEnum.ROMANCE.kor())))
-        val review = Review("", 3.0, 3.0, "", "", mockUser, theme)
-        every { modelMapper.map(any(), any<Class<*>>()) } returns review
+        every { modelMapper.map(any(), any<Class<*>>()) } returns getMockReview(GenreEnum.ROMANCE)
         val form = CreateReviewRequest("", "", 1.0, 1.0, "")
 
         // when

--- a/src/test/kotlin/jsonweb/exitserver/domain/boast/BoastServiceTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/boast/BoastServiceTest.kt
@@ -19,10 +19,10 @@ class BoastServiceTest : AnnotationSpec() {
     private val themeRepository: ThemeRepository = mockk()
     private val boastRepository: BoastRepository = mockk()
     private val boastLikeRepository: BoastLikeRepository = mockk()
-    private val boastReportRepository: BoastReportRepository = mockk()
+//    private val boastReportRepository: BoastReportRepository = mockk()
 
     private val boastService: BoastService = spyk(
-        BoastService(userService, themeRepository, boastRepository, boastLikeRepository, boastReportRepository),
+        BoastService(userService, themeRepository, boastRepository, boastLikeRepository),
         recordPrivateCalls = true
     )
 

--- a/src/test/kotlin/jsonweb/exitserver/domain/boast/BoastServiceTest.kt
+++ b/src/test/kotlin/jsonweb/exitserver/domain/boast/BoastServiceTest.kt
@@ -19,7 +19,6 @@ class BoastServiceTest : AnnotationSpec() {
     private val themeRepository: ThemeRepository = mockk()
     private val boastRepository: BoastRepository = mockk()
     private val boastLikeRepository: BoastLikeRepository = mockk()
-//    private val boastReportRepository: BoastReportRepository = mockk()
 
     private val boastService: BoastService = spyk(
         BoastService(userService, themeRepository, boastRepository, boastLikeRepository),
@@ -77,7 +76,7 @@ class BoastServiceTest : AnnotationSpec() {
         boastService.createBoast(form)
 
         // then
-        assertSoftly(mockUser.myBoastList) {
+        assertSoftly(mockUser.boastList) {
             size shouldBe 1
             first().imageUrl shouldBe imageUrl
             first().hashtagList.first().hashtag shouldBe "#${hashtags.first()}"
@@ -102,7 +101,7 @@ class BoastServiceTest : AnnotationSpec() {
         boastService.updateBoast(1L ,form)
 
         // then
-        assertSoftly(mockUser.myBoastList) {
+        assertSoftly(mockUser.boastList) {
             size shouldBe 1
             first().imageUrl shouldBe "https://image.com/4"
             first().hashtagList[0].hashtag shouldBe "#${hashtags[0]}"


### PR DESCRIPTION
### 작업 내용
- 경험치 획득 로직 추가
- 뱃지 획득 로직 추가

-> 테스트 방법
Test 디렉토리의 badge 패키지로 가면 각 도메인 별 테스트코드가 있습니다.

### 알림 사항
- 신고 관련 로직은 신고용 뱃지만 위해서 최소로 작성하였고, 나중에 관리자페이지 레이아웃이 나오면 추가로 작성할 예정입니다.
